### PR TITLE
Plumb through errors when loading/saving gists fail

### DIFF
--- a/ui/frontend/Output/Gist.tsx
+++ b/ui/frontend/Output/Gist.tsx
@@ -15,6 +15,7 @@ import {
 import Loader from './Loader';
 
 interface GistProps {
+  error?: string;
   codeUrl?: string;
   gistUrl?: string;
   issueUrl?: string;
@@ -25,7 +26,7 @@ interface GistProps {
 
 const Gist: React.SFC<GistProps> = props => (
   <div className="output-gist">
-    {props.showLoader ? <Loader /> : <Links {...props} />}
+    {props.error ? props.error : props.showLoader ? <Loader /> : <Links {...props} />}
   </div>
 );
 
@@ -74,6 +75,7 @@ class Copied extends React.PureComponent<CopiedProps, CopiedState> {
 }
 
 const mapStateToProps = (state: State) => ({
+  error: state.output.gist.error,
   codeUrl: codeUrlSelector(state),
   gistUrl: state.output.gist.url,
   issueUrl: issueUrlSelector(state),

--- a/ui/frontend/reducers/output/gist.ts
+++ b/ui/frontend/reducers/output/gist.ts
@@ -39,9 +39,15 @@ export default function gist(state = DEFAULT, action: Action): State {
       return finish(state, { id, url, code, stdout, stderr, channel, mode, edition });
     }
 
-    case ActionType.GistLoadFailed:
-    case ActionType.GistSaveFailed:
-      return finish(state, { error: 'Some kind of error' });
+    case ActionType.GistLoadFailed: {
+      const { id, error } = action;
+      return finish(state, { error: `Error loading gist ${id}: ${error}` });
+    }
+
+    case ActionType.GistSaveFailed: {
+      const { error } = action;
+      return finish(state, { error: `Error saving gist: ${error}` });
+    }
 
     default:
       return state;


### PR DESCRIPTION
Just noticed that it looks like it's infinitely loading if you accidentally mess up the gist id, [example link](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=b3354e29612baf458966c4df0916fde3).

One other small change to make the error messages more useful is to fall back to the HTTP status text if a non-JSON error response is returned. Users that actually care about the conversion failure are probably going to be checking the network tab in debug tools to see what's going wrong anyway.