### PR TITLE
Highlight errors in stdout under Test mode

### DIFF
--- a/ui/frontend/Output/Execute.tsx
+++ b/ui/frontend/Output/Execute.tsx
@@ -13,12 +13,13 @@ import styles from './Execute.module.css';
 const Execute: React.FC = () => {
   const details = useSelector((state: State) => state.output.execute);
   const isAutoBuild = useSelector(selectors.isAutoBuildSelector);
+  const isTest = useSelector(selectors.isTestPrimaryAction)
 
   const dispatch = useDispatch();
   const addMainFunction = useCallback(() => dispatch(actions.addMainFunction()), [dispatch]);
 
   return (
-    <SimplePane {...details} kind="execute">
+    <SimplePane highlightStdOut={isTest} {...details} kind="execute">
       {isAutoBuild && <Warning addMainFunction={addMainFunction} />}
     </SimplePane>
 

--- a/ui/frontend/Output/SimplePane.tsx
+++ b/ui/frontend/Output/SimplePane.tsx
@@ -24,6 +24,7 @@ export interface SimplePaneProps extends ReallySimplePaneProps {
 
 export interface ReallySimplePaneProps {
   requestsInProgress: number;
+  highlightStdOut?: boolean
   stdout?: string;
   stderr?: string;
   error?: string;
@@ -34,7 +35,9 @@ const SimplePane: React.FC<SimplePaneProps> = props => (
     {(props.requestsInProgress > 0) && <Loader />}
     <Section kind="error" label="Errors">{props.error}</Section>
     <HighlightErrors label="Standard Error">{props.stderr}</HighlightErrors>
-    <Section kind="stdout" label="Standard Output">{props.stdout}</Section>
+    {props.highlightStdOut ?
+      <HighlightErrors label="Standard Output">{props.stdout}</HighlightErrors> :
+      <Section kind="stdout" label="Standard Output">{props.stdout}</Section>}
     {props.children}
   </div>
 );

--- a/ui/frontend/selectors/index.ts
+++ b/ui/frontend/selectors/index.ts
@@ -60,6 +60,11 @@ export const getCrateType = createSelector(
 
 const rawPrimaryActionSelector = (state: State) => state.configuration.primaryAction;
 
+export const isTestPrimaryAction = createSelector(
+  rawPrimaryActionSelector,
+  (primaryAction) => (primaryAction === PrimaryActionCore.Test),
+)
+
 export const isAutoBuildSelector = createSelector(
   rawPrimaryActionSelector,
   autoPrimaryActionSelector,


### PR DESCRIPTION
While playing with doctest on playground, I just noticed the errors are not highlighted under `test` mode. Thus, I wonder it might be helpful to highlight errors if users are running tests.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/6782666/182009556-7e2bfb08-b023-40e9-8d75-be580b4dfd71.png) | ![image](https://user-images.githubusercontent.com/6782666/182009558-29d70ad5-90e4-4b24-b2f5-e796a89ee6a2.png) |

On the other hand, based on the impl in this PR, it will only highlight errors if users are using `Test` primary action so it will _not_ highlight stdout under `Run` or `Build` modes (like following picture):

![image](https://user-images.githubusercontent.com/6782666/182009584-4712ca2a-bbb0-4126-af74-a8a10bb41a05.png)

