### PR TITLE
Add a security notice to commonly inspected files

### DIFF
--- a/compiler/base/Dockerfile
+++ b/compiler/base/Dockerfile
@@ -20,6 +20,13 @@ RUN apt-get update && apt-get install -y \
 
 RUN useradd -m playground -d /playground
 RUN usermod -p '!!' root # Disable all passwords for root
+
+# Attach the security note
+ADD --chown=playground attach_notice.sh security_notice.txt /playground/
+RUN /playground/attach_notice.sh /playground/security_notice.txt /etc/passwd && \
+    /playground/attach_notice.sh /playground/security_notice.txt /etc/shadow && \
+    rm -f /playground/attach_notice.sh
+
 USER playground
 ENV USER=playground
 ENV PATH=/playground/.cargo/bin:$PATH

--- a/compiler/base/attach_notice.sh
+++ b/compiler/base/attach_notice.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -eu
+
+NOTICE_FILE=$1 # full path to the notice file
+TARGET_FILE=$2 # full patch to the target file
+
+POSITION=${3:-"top"} # possible values: top or bottom; default value: top
+
+function attach_notice() {
+    echo "Attaching ${NOTICE_FILE} to ${TARGET_FILE} (position: ${POSITION})"
+
+    if [[ "${POSITION}" == "bottom" ]]; then
+        cat "${NOTICE_FILE}" >> "${TARGET_FILE}"
+    else
+        combined=$(mktemp)
+        cat "${NOTICE_FILE}" "${TARGET_FILE}" >> "${combined}"
+        chmod --reference "${TARGET_FILE}" "${combined}"
+        mv "${combined}" "${TARGET_FILE}"
+    fi
+
+    echo "Done."
+}
+
+if [[ -f "${NOTICE_FILE}" ]] && [[ -f "${TARGET_FILE}" ]]; then
+    attach_notice
+fi

--- a/compiler/base/security_notice.txt
+++ b/compiler/base/security_notice.txt
@@ -1,0 +1,11 @@
+# Hello, and thanks for looking into the Rust Playground's security!
+#
+# This build is running on an unprivileged, sandboxed Docker container with no
+# network access, so while you can technically run arbitrary code on the
+# Playground you shouldn't be able to do any damage with it.
+#
+# Nothing is perfect though: if you find a way to escape the sandbox, please
+# disclose it following our security policy! You can find the policy at:
+#
+#    https://www.rust-lang.org/policies/security
+#

--- a/tests/spec/features/security_spec.rb
+++ b/tests/spec/features/security_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+require 'support/editor'
+require 'support/playground_actions'
+
+RSpec.feature "Security concerns", type: :feature, js: true do
+  include PlaygroundActions
+
+  before do
+    visit '/'
+    editor.set(code)
+  end
+
+  scenario "a notice is present for filesystem snoopers" do
+    within(:header) { click_on("Run") }
+    within(:output, :stdout) do
+      expect(page).to have_content 'www.rust-lang.org/policies/security'
+    end
+  end
+
+  def editor
+    Editor.new(page)
+  end
+
+  def code
+    <<~EOF
+    fn main() {
+        println!("{}", std::fs::read_to_string("/etc/passwd").unwrap());
+    }
+    EOF
+  end
+end


### PR DESCRIPTION
I've added a fairly generic script that allows to include any text file to any other text file, either on top or on the bottom, based on the arguments passed during the execution (just in case a similar need arie in the future for another use case). 

I've also updated the Dockerfile to execute the script at the end (before the entrypoint). Since the intention was to modify `/etc/passwd` and `/etc/shadow` files, I had to change the `USER` to `root` temporarily. After the files are updated, I changed the user back to `playground`.

The security notice I copied as is from #626. 

The updates are done from `/tmp` folder and at the end the script is removed. However, I decided to leave the security notice itself in the `playground` folder: `/playground/security_notice.txt` so that as soon as someone enumerates the content of the current directory, they will see the file.