### PR TITLE
Upgrade to Ace 1.23.1

### DIFF
--- a/ui/frontend/package.json
+++ b/ui/frontend/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.24.0",
     "@reduxjs/toolkit": "^1.8.5",
-    "ace-builds": "1.22.1",
+    "ace-builds": "^1.23.0",
     "common-tags": "^1.8.0",
     "core-js": "^3.1.3",
     "history": "^5.3.0",

--- a/ui/frontend/webpack.config.js
+++ b/ui/frontend/webpack.config.js
@@ -19,6 +19,7 @@ const allKeybindingNames =
 const allThemeNames =
       globSync('./node_modules/ace-builds/src-noconflict/theme-*.js')
       .map(basename)
+      .filter(n => !n.endsWith('-css'))
       .map(n => n.replace(/^theme-/, ''));
 
 // There's a builtin/default keybinding that we call `ace`.

--- a/ui/frontend/yarn.lock
+++ b/ui/frontend/yarn.lock
@@ -1978,10 +1978,10 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-ace-builds@1.22.1:
-  version "1.22.1"
-  resolved "https://registry.yarnpkg.com/ace-builds/-/ace-builds-1.22.1.tgz#3d765d1cfffc79226e372b6353750fd997816154"
-  integrity sha512-o5RGTPBIiRxguWNors3pT6KuLqj0a2NvNLoqir7/2LLiFm34PJV3BMq4sl9kjPayo4+lmd99m6zAq+XPdhyHQA==
+ace-builds@^1.23.0:
+  version "1.23.1"
+  resolved "https://registry.yarnpkg.com/ace-builds/-/ace-builds-1.23.1.tgz#2a1a2c2717c21cfd102f641552cf371ab6bce6e4"
+  integrity sha512-vmLfsfOOvEiQPri2Vz+76FvUalz/nHB7+X2GqonG7rc2V+WrHvqc4xYowt1+fxHH3aWw/pDF2jqKQrd8JNMmiQ==
 
 acorn-import-assertions@^1.9.0:
   version "1.9.0"


### PR DESCRIPTION
Ace 1.23 introduces `theme-${name}-css.js` files alongside the existing `theme-${name}.js` files. These files only define the CSS (as suggested by their name) and so aren't valid as theme choices. The existing files include both the JS and CSS. Filter out the new files from our theme choices.

Closes #941