### PR TITLE
Remove our code that triggered Ace resizes

### DIFF
--- a/ui/frontend/Playground.tsx
+++ b/ui/frontend/Playground.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useEffect, useRef } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import React, { useEffect, useRef } from 'react';
+import { useSelector } from 'react-redux';
 import Split from 'split-grid';
 
 import Editor from './editor/Editor';
@@ -8,7 +8,6 @@ import Notifications from './Notifications';
 import Output from './Output';
 import * as selectors from './selectors';
 import { Orientation } from './types';
-import * as actions from './actions';
 
 import styles from './Playground.module.css';
 
@@ -41,9 +40,6 @@ const ResizableArea: React.FC = () => {
   const isFocused = useSelector(selectors.isOutputFocused);
   const orientation = useSelector(selectors.orientation);
 
-  const dispatch = useDispatch();
-  const resizeComplete = useCallback(() => dispatch(actions.splitRatioChanged()), [dispatch]);
-
   const grid = useRef<HTMLDivElement | null>(null);
   const dragHandle = useRef(null);
 
@@ -53,9 +49,7 @@ const ResizableArea: React.FC = () => {
       grid.current.style.removeProperty('grid-template-columns');
       grid.current.style.removeProperty('grid-template-rows');
     }
-
-    resizeComplete();
-  }, [orientation, isFocused, resizeComplete])
+  }, [orientation, isFocused])
 
   useEffect(() => {
     const split = Split({
@@ -64,11 +58,10 @@ const ResizableArea: React.FC = () => {
         track: 1,
         element: dragHandle.current,
       }],
-      onDragEnd: resizeComplete,
     });
 
     return () => split.destroy();
-  }, [orientation, isFocused, somethingToShow, resizeComplete])
+  }, [orientation, isFocused, somethingToShow])
 
   const gridStyles = isFocused ? FOCUSED_GRID_STYLE : UNFOCUSED_GRID_STYLE;
   const gridStyle = gridStyles[orientation];

--- a/ui/frontend/actions.ts
+++ b/ui/frontend/actions.ts
@@ -118,7 +118,6 @@ export enum ActionType {
   VersionsLoadSucceeded = 'VERSIONS_LOAD_SUCCEEDED',
   NotificationSeen = 'NOTIFICATION_SEEN',
   BrowserWidthChanged = 'BROWSER_WIDTH_CHANGED',
-  SplitRatioChanged = 'SPLIT_RATIO_CHANGED',
 }
 
 export const initializeApplication = () => createAction(ActionType.InitializeApplication);
@@ -669,9 +668,6 @@ export const seenRustSurvey2022 = () => notificationSeen(Notification.RustSurvey
 export const browserWidthChanged = (isSmall: boolean) =>
   createAction(ActionType.BrowserWidthChanged, { isSmall });
 
-export const splitRatioChanged = () =>
-  createAction(ActionType.SplitRatioChanged);
-
 function parseChannel(s?: string): Channel | null {
   switch (s) {
     case 'stable':
@@ -812,6 +808,5 @@ export type Action =
   | ReturnType<typeof receiveVersionsLoadSuccess>
   | ReturnType<typeof notificationSeen>
   | ReturnType<typeof browserWidthChanged>
-  | ReturnType<typeof splitRatioChanged>
   | ReturnType<typeof wsExecuteRequest>
   ;

--- a/ui/frontend/editor/AceEditor.tsx
+++ b/ui/frontend/editor/AceEditor.tsx
@@ -5,7 +5,6 @@ import { suspend } from 'suspend-react';
 import {
   aceKeybinding,
   acePairCharacters,
-  aceResizeKey,
   aceTheme,
   offerCrateAutocompleteOnUse,
 } from '../selectors';
@@ -41,7 +40,6 @@ const AceEditorLazy = React.lazy(() => import('./AceEditorCore'));
 //
 // Themes and keybindings can be changed at runtime.
 const AceEditorAsync: React.FC<CommonEditorProps> = (props) => {
-  const resizeKey = useSelector(aceResizeKey);
   const autocompleteOnUse = useSelector(offerCrateAutocompleteOnUse);
   const keybinding = useSelector(aceKeybinding);
   const pairCharacters = useSelector(acePairCharacters);
@@ -55,7 +53,6 @@ const AceEditorAsync: React.FC<CommonEditorProps> = (props) => {
         autocompleteOnUse={autocompleteOnUse}
         keybinding={keybinding}
         pairCharacters={pairCharacters}
-        resizeKey={resizeKey}
         theme={theme}
       />
     </Suspense>

--- a/ui/frontend/editor/AceEditorCore.tsx
+++ b/ui/frontend/editor/AceEditorCore.tsx
@@ -6,7 +6,7 @@ import 'ace-builds/src-noconflict/ext-searchbox';
 import 'ace-builds/src-noconflict/mode-rust';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { AceResizeKey, Crate, PairCharacters, Position, Selection } from '../types';
+import { Crate, PairCharacters, Position, Selection } from '../types';
 
 import styles from './Editor.module.css';
 
@@ -89,7 +89,6 @@ interface AceEditorProps {
   selection: Selection;
   theme: string;
   crates: Crate[];
-  resizeKey?: AceResizeKey;
   pairCharacters: PairCharacters;
 }
 
@@ -294,20 +293,6 @@ const AceEditor: React.FC<AceEditorProps> = props => {
       editor.renderer.scrollCursorIntoView(start);
       editor.focus();
     }
-  }, []));
-
-  // There's a tricky bug with Ace:
-  //
-  // 1. Open the page
-  // 2. Fill up the page with text but do not cause scrolling
-  // 3. Run the code (causing the pane to cover some of the text)
-  // 4. Try to scroll
-  //
-  // Ace doesn't know that we changed the visible area and so
-  // doesn't recalculate. We track factors that lead to this case to
-  // force such a recalculation.
-  useEditorProp(editor, props.resizeKey, useCallback((editor, _resizeKey) => {
-    editor.resize();
   }, []));
 
   return (

--- a/ui/frontend/reducers/browser.ts
+++ b/ui/frontend/reducers/browser.ts
@@ -2,23 +2,16 @@ import { Action, ActionType } from '../actions';
 
 const DEFAULT: State = {
   isSmall: true,
-  ratioGeneration: 0,
 };
 
 export type State = {
   isSmall: boolean;
-  ratioGeneration: number;
 };
 
 export default function code(state = DEFAULT, action: Action): State {
   switch (action.type) {
     case ActionType.BrowserWidthChanged:
       return { ...state, isSmall: action.isSmall };
-    case ActionType.SplitRatioChanged: {
-      let { ratioGeneration } = state;
-      ratioGeneration++;
-      return { ...state, ratioGeneration };
-    }
 
     default:
       return state;

--- a/ui/frontend/selectors/index.ts
+++ b/ui/frontend/selectors/index.ts
@@ -3,7 +3,6 @@ import { createSelector } from '@reduxjs/toolkit';
 
 import { State } from '../reducers';
 import {
-  AceResizeKey,
   Backtrace,
   Channel,
   Edition,
@@ -327,14 +326,6 @@ export const orientation = createSelector(
       return orientation;
     }
   }
-)
-
-const ratioGeneration = (state: State) => state.browser.ratioGeneration;
-
-export const aceResizeKey = createSelector(
-  focus,
-  ratioGeneration,
-  (focus, ratioGeneration): AceResizeKey => [focus, ratioGeneration],
 )
 
 const aceConfig = (s: State) => s.configuration.ace;

--- a/ui/frontend/types.ts
+++ b/ui/frontend/types.ts
@@ -122,5 +122,3 @@ export enum Focus {
 export enum Notification {
   RustSurvey2022 = 'rust-survey-2022',
 }
-
-export type AceResizeKey = [Focus | undefined, number];


### PR DESCRIPTION
[Ace added a `ResizeObserver`][pr-5095] to automatically perform resizes as needed, so we can remove our junk — hooray!

[pr-5095]: https://github.com/ajaxorg/ace/pull/5095