### PR TITLE
Try to send larger stdout / stderr packets

### DIFF
--- a/compiler/base/orchestrator/Cargo.lock
+++ b/compiler/base/orchestrator/Cargo.lock
@@ -37,6 +37,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "assertables"
 version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,6 +302,7 @@ name = "orchestrator"
 version = "0.1.0"
 dependencies = [
  "asm-cleanup",
+ "assert_matches",
  "assertables",
  "bincode",
  "futures",

--- a/compiler/base/orchestrator/Cargo.toml
+++ b/compiler/base/orchestrator/Cargo.toml
@@ -20,5 +20,6 @@ toml = { version = "0.7.3", default-features = false, features = ["parse", "disp
 tracing = { version = "0.1.37", default-features = false, features = ["attributes"] }
 
 [dev-dependencies]
+assert_matches = "1.5.0"
 assertables = "7.0.1"
 tempdir = "0.3.7"


### PR DESCRIPTION
Line-based messages were fine for small examples, but if someone writes 10K lines, that translates to 10K WebSocket messages, which is a bit excessive.

This tries to grab up to 32K of UTF-8 text at once, managing the possibility of UTF-8 characters being split across the buffer.

Running the code `for _ in 0..128_000 { println!("a"); }` resulted in

```
Before: 71445 messages (and Chrome died)
After:   2631 messages
```