### PR TITLE
Support Firefox 91.13.0esr which does not provide crypto.randomUUID

### DIFF
--- a/ui/frontend/index.tsx
+++ b/ui/frontend/index.tsx
@@ -7,6 +7,7 @@ import './index.module.css';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
+import { v4 } from 'uuid';
 
 import {
   editCode,
@@ -33,7 +34,7 @@ const store = configureStore(window);
 if (store.getState().client.id === '') {
   const { crypto } = window;
 
-  const id = crypto.randomUUID();
+  const id = v4();
 
   const rawValue = new Uint32Array(1);
   crypto.getRandomValues(rawValue);

--- a/ui/frontend/package.json
+++ b/ui/frontend/package.json
@@ -27,6 +27,7 @@
     "route-parser": "^0.0.5",
     "split-grid": "^1.0.9",
     "suspend-react": "^0.1.3",
+    "uuid": "^9.0.0",
     "zod": "^3.20.3"
   },
   "devDependencies": {
@@ -48,6 +49,7 @@
     "@types/react-dom": "^18.0.10",
     "@types/react-portal": "^4.0.4",
     "@types/route-parser": "^0.1.4",
+    "@types/uuid": "^9.0.2",
     "@typescript-eslint/eslint-plugin": "^5.9.0",
     "@typescript-eslint/parser": "^5.9.0",
     "autoprefixer": "^10.2.4",

--- a/ui/frontend/yarn.lock
+++ b/ui/frontend/yarn.lock
@@ -1736,6 +1736,11 @@
   resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
   integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
 
+"@types/uuid@^9.0.2":
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.2.tgz#ede1d1b1e451548d44919dc226253e32a6952c4b"
+  integrity sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==
+
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
@@ -6217,6 +6222,11 @@ utila@~0.4:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
   integrity sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==
+
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-to-istanbul@^9.0.1:
   version "9.1.0"


### PR DESCRIPTION
This is easy enough to support, even though it's outside of our support window.

Closes #957