### PR TITLE
Replace the CancellationToken with a new one when idling

### DIFF
--- a/compiler/base/orchestrator/src/coordinator.rs
+++ b/compiler/base/orchestrator/src/coordinator.rs
@@ -484,6 +484,8 @@ where
             token,
             ..
         } = self;
+
+        let token = mem::take(token);
         token.cancel();
 
         let channels =


### PR DESCRIPTION
Otherwise, the token stays canceled and all subsequent attempts to spawn a child immediately exit.

Fixes #974