### PR TITLE
Encourage the OOM killer to pick the container processes

### DIFF
--- a/compiler/base/orchestrator/src/coordinator.rs
+++ b/compiler/base/orchestrator/src/coordinator.rs
@@ -1211,6 +1211,8 @@ fn basic_secure_docker_command() -> Command {
         "640m",
         "--pids-limit",
         "512",
+        "--oom-score-adj",
+        "1000",
     )
 }
 

--- a/ui/src/sandbox.rs
+++ b/ui/src/sandbox.rs
@@ -137,6 +137,8 @@ fn basic_secure_docker_command() -> Command {
             "PLAYGROUND_TIMEOUT={}",
             DOCKER_PROCESS_TIMEOUT_SOFT.as_secs()
         ),
+        "--oom-score-adj",
+        "1000",
     );
 
     if cfg!(feature = "fork-bomb-prevention") {


### PR DESCRIPTION
play.rust-lang.org has had a few outages because the machine is a bit low on memory and the OOM killer picks to reap nginx. There are many containers running using a small amount of memory while the one nginx uses more, so it's a more attractive target.

My ideal situation would be if we could group all the containers and kill from that pool until the memory pressure is resolved, but I don't know how to do that.