### PR TITLE
Kill the container ourselves when done

### DIFF
--- a/compiler/base/orchestrator/Cargo.toml
+++ b/compiler/base/orchestrator/Cargo.toml
@@ -11,6 +11,7 @@ asm-cleanup = { path = "../asm-cleanup" }
 bincode = { version = "1.3", default-features = false }
 futures = { version = "0.3.28", default-features = false, features = ["executor"] }
 modify-cargo-toml = { path = "../modify-cargo-toml", default-features = false }
+once_cell = { version = "1.18.0", default-features = false, features = ["std"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.108", default-features = false, features = ["std"] }
 snafu = { version = "0.7.4", default-features = false, features = ["futures", "std"] }

--- a/ui/Cargo.lock
+++ b/ui/Cargo.lock
@@ -1035,6 +1035,7 @@ dependencies = [
  "libc",
  "mach2",
  "modify-cargo-toml",
+ "once_cell",
  "procfs",
  "serde",
  "serde_json",


### PR DESCRIPTION
We stream messages from the coordinator to the worker via stdin/stdout piped to `docker run`. However, sometimes we close the pipe corresponding to `docker run`'s stdout before it has had a chance to fully write everything. If that happens, `docker run` exits without deleting the container [1].

This has likely always been a problem with the coordinator / worker architecture, but it's exacerbated by the recent addition of the memory / CPU status messages that occur every second, which greatly increase the amount of data crossing the boundary.

This reorganizes the code to pass in a known reasonably unique name to the container and then attempts to kill that container at cleanup time.

I tested by:

- Setting the worker status interval to 16ms (from 1s)
- Setting the webserver idle interval to 7s (from 60s)
- Setting the webserver session timeout to 14s (from 45m)
- Running code that prints infinitely (`loop { println!("moo"); }`)

This reliably recreated the `write /dev/stdout: broken pipe` error from the `docker run` invocation, but after this commit there were no vestigial running containers.

[1]: https://github.com/moby/moby/issues/38769