### PR TITLE
Add dark mode

### DIFF
--- a/ui/frontend/.stylelintrc.json
+++ b/ui/frontend/.stylelintrc.json
@@ -12,6 +12,9 @@
       "ignoreProperties": [
         "composes"
       ]
+    }],
+    "at-rule-no-unknown": [true, {
+      "ignoreAtRules": ["define-mixin", "mixin"]
     }]
   }
 }

--- a/ui/frontend/BuildMenu.module.css
+++ b/ui/frontend/BuildMenu.module.css
@@ -1,4 +1,4 @@
 .code {
-  background: #eee;
+  background: var(--code-background-color);
   padding: 0 0.25em;
 }

--- a/ui/frontend/ButtonSet.module.css
+++ b/ui/frontend/ButtonSet.module.css
@@ -76,11 +76,7 @@ $radius: 4px;
 
 .secondary {
   composes: -border -button;
-  background: linear-gradient(
-    to bottom,
-    var(--button-secondary-bg-color-top),
-    var(--button-secondary-bg-color-bottom)
-  );
+  background: var(--button-secondary-bg-color);
   border-color: var(--button-secondary-border-color);
   color: var(--button-secondary-color);
 
@@ -121,4 +117,9 @@ $radius: 4px;
   padding: 0;
   aspect-ratio: 1/1;
   justify-items: center;
+}
+
+a.iconLink svg,
+a.iconLink:visited svg {
+  fill: var(--font-color) !important;
 }

--- a/ui/frontend/ButtonSet.tsx
+++ b/ui/frontend/ButtonSet.tsx
@@ -79,7 +79,7 @@ IconButton.displayName = 'IconButton';
 
 export const IconLink = React.forwardRef<HTMLAnchorElement, LinkProps>(
   ({ children, ...props }, ref) => (
-    <Link ref={ref} className={styles.icon} {...props}>
+    <Link ref={ref} className={`${styles.icon} ${styles.iconLink}`} {...props}>
       {children}
     </Link>
   ),

--- a/ui/frontend/ConfigElement.module.css
+++ b/ui/frontend/ConfigElement.module.css
@@ -20,6 +20,15 @@
 
 .select {
   width: 100%;
+  background: var(--button-secondary-bg-color);
+  border-color: var(--button-secondary-border-color);
+  color: var(--button-secondary-color);
+
+  & option {
+    background-color: var(--button-secondary-bg-color-top);
+    border-color: var(--button-secondary-border-color);
+    color: var(--button-secondary-color);
+  }
 }
 
 .toggle {

--- a/ui/frontend/ConfigMenu.tsx
+++ b/ui/frontend/ConfigMenu.tsx
@@ -14,6 +14,7 @@ import {
   Orientation,
   PairCharacters,
   ProcessAssembly,
+  Theme,
 } from './types';
 
 const MONACO_THEMES = [
@@ -24,6 +25,7 @@ const ConfigMenu: React.FC = () => {
   const keybinding = useAppSelector((state) => state.configuration.ace.keybinding);
   const aceTheme = useAppSelector((state) => state.configuration.ace.theme);
   const monacoTheme = useAppSelector((state) => state.configuration.monaco.theme);
+  const theme = useAppSelector((state) => state.configuration.theme);
   const orientation = useAppSelector((state) => state.configuration.orientation);
   const editorStyle = useAppSelector((state) => state.configuration.editor);
   const pairCharacters = useAppSelector((state) => state.configuration.ace.pairCharacters);
@@ -35,6 +37,7 @@ const ConfigMenu: React.FC = () => {
   const changeAceTheme = useCallback((t: string) => dispatch(config.changeAceTheme(t)), [dispatch]);
   const changeMonacoTheme = useCallback((t: string) => dispatch(config.changeMonacoTheme(t)), [dispatch]);
   const changeKeybinding = useCallback((k: string) => dispatch(config.changeKeybinding(k)), [dispatch]);
+  const changeTheme = useCallback((t: Theme) => dispatch(config.changeTheme(t)), [dispatch]);
   const changeOrientation = useCallback((o: Orientation) => dispatch(config.changeOrientation(o)), [dispatch]);
   const changeEditorStyle = useCallback((e: Editor) => dispatch(config.changeEditor(e)), [dispatch]);
   const changeAssemblyFlavor =
@@ -98,6 +101,11 @@ const ConfigMenu: React.FC = () => {
       </MenuGroup>
 
       <MenuGroup title="UI">
+        <SelectConfig name="Theme" value={theme} onChange={changeTheme}>
+          <option value={Theme.System}>System</option>
+          <option value={Theme.Light}>Light</option>
+          <option value={Theme.Dark}>Dark</option>
+        </SelectConfig>
         <SelectConfig
           name="Orientation"
           value={orientation}

--- a/ui/frontend/ConfigMenu.tsx
+++ b/ui/frontend/ConfigMenu.tsx
@@ -16,6 +16,7 @@ import {
   ProcessAssembly,
   Theme,
 } from './types';
+import { showThemeSelector } from './selectors';
 
 const MONACO_THEMES = [
   'vs', 'vs-dark', 'vscode-dark-plus',
@@ -32,6 +33,8 @@ const ConfigMenu: React.FC = () => {
   const assemblyFlavor = useAppSelector((state) => state.configuration.assemblyFlavor);
   const demangleAssembly = useAppSelector((state) => state.configuration.demangleAssembly);
   const processAssembly = useAppSelector((state) => state.configuration.processAssembly);
+
+  const showTheme = useAppSelector(showThemeSelector);
 
   const dispatch = useAppDispatch();
   const changeAceTheme = useCallback((t: string) => dispatch(config.changeAceTheme(t)), [dispatch]);
@@ -101,11 +104,13 @@ const ConfigMenu: React.FC = () => {
       </MenuGroup>
 
       <MenuGroup title="UI">
-        <SelectConfig name="Theme" value={theme} onChange={changeTheme}>
-          <option value={Theme.System}>System</option>
-          <option value={Theme.Light}>Light</option>
-          <option value={Theme.Dark}>Dark</option>
-        </SelectConfig>
+        {showTheme && (
+          <SelectConfig name="Theme" value={theme} onChange={changeTheme}>
+            { /* <option value={Theme.System}>System</option> */ }
+            <option value={Theme.Light}>Light</option>
+            <option value={Theme.Dark}>Dark</option>
+          </SelectConfig>
+        )}
         <SelectConfig
           name="Orientation"
           value={orientation}

--- a/ui/frontend/Help.module.css
+++ b/ui/frontend/Help.module.css
@@ -1,13 +1,14 @@
 .container {
   margin: 1em auto;
-  background-color: #fff;
+  color: var(--font-color-high-contrast);
+  background-color: var(--background-color-high-contrast);
   padding: 1em;
   max-width: 800px;
   line-height: 1.5;
 }
 
 .code {
-  background: #eee;
+  background: var(--code-background-color);
   padding: 0 0.25em;
 }
 
@@ -22,7 +23,7 @@
 }
 
 .headerLink {
-  color: black;
+  color: var(--header-link-color);
   text-decoration: none;
 
   &:hover {

--- a/ui/frontend/Notifications.module.css
+++ b/ui/frontend/Notifications.module.css
@@ -10,7 +10,7 @@ $space: 0.25em;
   margin-right: auto;
   margin-left: auto;
   border: 2px solid #428bca;
-  background: white;
+  background: var(--background-color);
   max-width: 50em;
 }
 
@@ -25,7 +25,6 @@ $space: 0.25em;
 .close {
   composes: -buttonReset from './shared.module.css';
   cursor: pointer;
-  background: #e1e1db;
   padding: $space;
 }
 

--- a/ui/frontend/Output.module.css
+++ b/ui/frontend/Output.module.css
@@ -1,6 +1,3 @@
-$current-tab: #f9ffff;
-$background-tab: #fcfcfc; /* desaturate($current-tab, 100%); */
-
 .container {
   display: flex;
   flex-direction: column;
@@ -13,11 +10,12 @@ $background-tab: #fcfcfc; /* desaturate($current-tab, 100%); */
 }
 
 .tab {
+  color: var(--font-color);
   flex: 1 1 auto;
   cursor: pointer;
   border: var(--border);
   border-right: none;
-  background-color: $background-tab;
+  background-color: var(--output-background-tab);
   line-height: 1.5em;
 
   &:last-of-type {
@@ -29,7 +27,7 @@ $background-tab: #fcfcfc; /* desaturate($current-tab, 100%); */
   composes: tab;
   cursor: default;
   border-bottom: none;
-  background-color: $current-tab;
+  background-color: var(--output-current-tab);
 
   &:focus {
     outline: none;
@@ -44,7 +42,7 @@ $background-tab: #fcfcfc; /* desaturate($current-tab, 100%); */
 .body {
   border: var(--border);
   border-top: none;
-  background-color: $current-tab;
+  background-color: var(--output-current-tab);
   padding: 0.5em;
   height: 100%;
   overflow: scroll;

--- a/ui/frontend/Output/Header.module.css
+++ b/ui/frontend/Output/Header.module.css
@@ -1,6 +1,6 @@
 .container {
   display: flex;
-  color: var(--border-color);
+  color: var(--font-color);
   white-space: nowrap;
 
   &::before,

--- a/ui/frontend/PopButton.module.css
+++ b/ui/frontend/PopButton.module.css
@@ -1,6 +1,3 @@
-$fg-color: #222;
-$bg-color: white;
-$vertical-border-color: #cacaca;
 $arrow-height: 10px;
 $arrow-width: 20px;
 
@@ -13,14 +10,18 @@ $arrow-width: 20px;
   }
 }
 
+.arrow {
+  fill: var(--background-color-high-contrast);
+}
+
 .-content {
   margin: $arrow-height;
   box-shadow:
     5px 5px 20px -3px rgb(0 0 0 / 25%),
     0 0 5px -2px rgb(0 0 0 / 90%);
   border-radius: var(--header-border-radius);
-  background: $bg-color;
-  color: $fg-color;
+  background: var(--background-color-high-contrast);
+  color: var(--font-color);
 }
 
 .contentBottom {

--- a/ui/frontend/PopButton.tsx
+++ b/ui/frontend/PopButton.tsx
@@ -72,7 +72,13 @@ const PopButton: React.FC<NewPopProps> = ({ Button, Menu, menuContainer }) => {
         }}
         {...getFloatingProps()}
       >
-        <FloatingArrow ref={arrowRef} context={context} height={10} width={20} fill="white" />
+        <FloatingArrow
+          ref={arrowRef}
+          context={context}
+          height={10}
+          width={20}
+          className={styles.arrow}
+        />
         <div className={containerClass}>
           <Menu close={close} />
         </div>

--- a/ui/frontend/configureStore.ts
+++ b/ui/frontend/configureStore.ts
@@ -23,7 +23,7 @@ export default function configureStore(window: Window) {
   const baseUrl = new URL('/', window.location.href).href;
   const websocket = websocketMiddleware(window);
 
-  const prefersDarkTheme = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const prefersDarkTheme = false && window.matchMedia('(prefers-color-scheme: dark)').matches;
   const initialThemes = prefersDarkTheme ? editorDarkThemes : {};
 
   const initialGlobalState = {

--- a/ui/frontend/configureStore.ts
+++ b/ui/frontend/configureStore.ts
@@ -8,9 +8,23 @@ import reducer from './reducers';
 import initializeSessionStorage from './session_storage';
 import { websocketMiddleware } from './websocketMiddleware';
 
+const editorDarkThemes = {
+  configuration: {
+    ace: {
+      theme: 'github_dark',
+    },
+    monaco: {
+      theme: 'vscode-dark-plus',
+    },
+  },
+};
+
 export default function configureStore(window: Window) {
   const baseUrl = new URL('/', window.location.href).href;
   const websocket = websocketMiddleware(window);
+
+  const prefersDarkTheme = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const initialThemes = prefersDarkTheme ? editorDarkThemes : {};
 
   const initialGlobalState = {
     globalConfiguration: {
@@ -26,6 +40,7 @@ export default function configureStore(window: Window) {
     merge(
       initialAppState,
       initialGlobalState,
+      initialThemes,
       localStorage.initialState,
       sessionStorage.initialState,
     ),

--- a/ui/frontend/index.module.css
+++ b/ui/frontend/index.module.css
@@ -11,9 +11,7 @@
   --border: 1px solid var(--border-color);
 }
 
-/* Light theme */
-/* stylelint-disable-next-line no-duplicate-selectors */
-:root {
+@define-mixin light-theme-vars {
   --positive-luminance: white;
   --negative-luminance: black;
 
@@ -107,48 +105,60 @@
   --output-current-tab: #f9ffff;
 }
 
-/* Automatic dark mode */
+@define-mixin dark-theme-vars {
+  --positive-luminance: black;
+  --negative-luminance: white;
+
+  /* Fonts */
+  --font-color: #b4aea6;
+  --font-color-high-contrast: #dcdbd8;
+
+  /* Links */
+  --link-color: #308af2;
+  --link-color-visited: #9f5fe1;
+
+  /* Background */
+  --background-color: #292c2e;
+  --background-color-high-contrast: #17191a;
+
+  /* Code */
+  --code-background-color: #3c3c3c;
+
+  /* Border */
+  --border-color: #404548;
+
+  /* Header */
+  --header-main-border: #363b3d;
+  --header-accent-border: #bdbdbd;
+
+  /* The big red button */
+  --button-primary-color: #dcdbd8;
+  --button-primary-bg-color: #81331a;
+  --button-primary-border-color: #612714;
+
+  /* Not the big red button */
+  --button-secondary-color: #b4aea6;
+  --button-secondary-bg-color-top: #17191a;
+  --button-secondary-bg-color-bottom: #1a1c1d;
+
+  /* Output tabs */
+  --output-background-tab: #191b1c;
+  --output-current-tab: #343434;
+}
+
+:root,
+[data-theme='light']:root {
+  @mixin light-theme-vars;
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
-    --positive-luminance: black;
-    --negative-luminance: white;
-
-    /* Fonts */
-    --font-color: #b4aea6;
-    --font-color-high-contrast: #dcdbd8;
-
-    /* Links */
-    --link-color: #308af2;
-    --link-color-visited: #9f5fe1;
-
-    /* Background */
-    --background-color: #292c2e;
-    --background-color-high-contrast: #17191a;
-
-    /* Code */
-    --code-background-color: #3c3c3c;
-
-    /* Border */
-    --border-color: #404548;
-
-    /* Header */
-    --header-main-border: #363b3d;
-    --header-accent-border: #bdbdbd;
-
-    /* The big red button */
-    --button-primary-color: #dcdbd8;
-    --button-primary-bg-color: #81331a;
-    --button-primary-border-color: #612714;
-
-    /* Not the big red button */
-    --button-secondary-color: #b4aea6;
-    --button-secondary-bg-color-top: #17191a;
-    --button-secondary-bg-color-bottom: #1a1c1d;
-
-    /* Output tabs */
-    --output-background-tab: #191b1c;
-    --output-current-tab: #343434;
+    @mixin dark-theme-vars;
   }
+}
+
+[data-theme='dark']:root {
+  @mixin dark-theme-vars;
 }
 
 /* Modify normalized styles */

--- a/ui/frontend/index.module.css
+++ b/ui/frontend/index.module.css
@@ -151,11 +151,13 @@
   @mixin light-theme-vars;
 }
 
+/*
 @media (prefers-color-scheme: dark) {
   :root {
     @mixin dark-theme-vars;
   }
 }
+*/
 
 [data-theme='dark']:root {
   @mixin dark-theme-vars;

--- a/ui/frontend/index.module.css
+++ b/ui/frontend/index.module.css
@@ -1,52 +1,154 @@
+/* Non-theme variables */
 :root {
+  /* Fonts */
   --primary-font: 'Open Sans', sans-serif;
-  --rust: #a42;
-  --rust-dark: #80331a;
-  --border-color: #bbb;
-  --border: 1px solid var(--border-color);
-  --header-main-border: #dedede;
+
+  /* Header */
   --header-transition: 0.2s ease-in-out;
-  --header-tint: #428bca;
   --header-border-radius: 4px;
+
+  /* Border */
+  --border: 1px solid var(--border-color);
+}
+
+/* Light theme */
+/* stylelint-disable-next-line no-duplicate-selectors */
+:root {
+  --positive-luminance: white;
+  --negative-luminance: black;
+
+  /* Fonts */
+  --font-color: #444;
+  --font-color-high-contrast: var(--negative-luminance);
+
+  /* Links */
+  --link-color: #00e;
+  --link-color-visited: #551a8b;
+
+  /* Background */
+  --background-color: #e1e1db;
+  --background-color-high-contrast: var(--positive-luminance);
+
+  /* Code */
+  --code-background-color: #eee;
+
+  /* Border */
+  --border-color: #bbb;
+
+  /* Header */
+  --header-link-color: var(--negative-luminance);
+  --header-main-border: #dedede;
+  --header-tint: #428bca;
   --header-accent-border: #bdbdbd;
 
   /* The big red button */
-
-  --button-primary-color: white;
-  --button-primary-bg-color: var(--rust);
-  --button-primary-border-color: var(--rust-dark);
-  --button-primary-bg-color-light: color-mix(in hsl, var(--button-primary-bg-color), white);
-  --button-primary-border-color-light: color-mix(in hsl, var(--button-primary-border-color), white);
+  --button-primary-color: var(--positive-luminance);
+  --button-primary-bg-color: #a42;
+  --button-primary-border-color: #80331a;
+  --button-primary-bg-color-light: color-mix(
+    in hsl,
+    var(--button-primary-bg-color),
+    var(--positive-luminance)
+  );
+  --button-primary-border-color-light: color-mix(
+    in hsl,
+    var(--button-primary-border-color),
+    var(--positive-luminance)
+  );
 
   /* Clicked */
-  --button-primary-active-color: color-mix(in hsl, white, black 30%);
+  --button-primary-active-color: color-mix(
+    in hsl,
+    var(--positive-luminance),
+    var(--negative-luminance) 30%
+  );
 
   /* Not the big red button */
-
   --button-secondary-color: #444;
   --button-secondary-bg-color-top: #fff;
   --button-secondary-bg-color-bottom: #f9f9f9;
+  --button-secondary-bg-color: linear-gradient(
+    to bottom,
+    var(--button-secondary-bg-color-top),
+    var(--button-secondary-bg-color-bottom)
+  );
   --button-secondary-border-color: color-mix(
     in hsl,
     var(--button-secondary-bg-color-bottom),
-    black 20%
+    var(--negative-luminance) 20%
   );
 
   /* Disabled */
   --button-secondary-bg-color-light: color-mix(
     in hsl,
     var(--button-secondary-bg-color-bottom),
-    white
+    var(--positive-luminance)
   );
   --button-secondary-border-color-light: color-mix(
     in hsl,
     var(--button-secondary-border-color),
-    white
+    var(--positive-luminance)
   );
-  --button-secondary-color-light: color-mix(in hsl, var(--button-secondary-color), white);
+  --button-secondary-color-light: color-mix(
+    in hsl,
+    var(--button-secondary-color),
+    var(--positive-luminance)
+  );
 
   /* Clicked */
-  --button-secondary-active-color: color-mix(in hsl, black, white 30%);
+  --button-secondary-active-color: color-mix(
+    in hsl,
+    var(--negative-luminance),
+    var(--positive-luminance) 30%
+  );
+
+  /* Output tabs */
+  --output-background-tab: #fcfcfc;
+  --output-current-tab: #f9ffff;
+}
+
+/* Automatic dark mode */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --positive-luminance: black;
+    --negative-luminance: white;
+
+    /* Fonts */
+    --font-color: #b4aea6;
+    --font-color-high-contrast: #dcdbd8;
+
+    /* Links */
+    --link-color: #308af2;
+    --link-color-visited: #9f5fe1;
+
+    /* Background */
+    --background-color: #292c2e;
+    --background-color-high-contrast: #17191a;
+
+    /* Code */
+    --code-background-color: #3c3c3c;
+
+    /* Border */
+    --border-color: #404548;
+
+    /* Header */
+    --header-main-border: #363b3d;
+    --header-accent-border: #bdbdbd;
+
+    /* The big red button */
+    --button-primary-color: #dcdbd8;
+    --button-primary-bg-color: #81331a;
+    --button-primary-border-color: #612714;
+
+    /* Not the big red button */
+    --button-secondary-color: #b4aea6;
+    --button-secondary-bg-color-top: #17191a;
+    --button-secondary-bg-color-bottom: #1a1c1d;
+
+    /* Output tabs */
+    --output-background-tab: #191b1c;
+    --output-current-tab: #343434;
+  }
 }
 
 /* Modify normalized styles */
@@ -55,12 +157,19 @@ input,
 optgroup,
 select,
 textarea {
-  color: text;
   font-family: var(--primary-font);
 }
 
 html {
   box-sizing: border-box;
+}
+
+a {
+  color: var(--link-color);
+}
+
+a:visited {
+  color: var(--link-color-visited);
 }
 
 *,
@@ -70,7 +179,8 @@ html {
 }
 
 body {
-  background-color: #e1e1db;
+  color: var(--font-color);
+  background-color: var(--background-color);
   padding: 0 1em;
   font-family: var(--primary-font);
 }

--- a/ui/frontend/index.tsx
+++ b/ui/frontend/index.tsx
@@ -25,6 +25,9 @@ import { gotoPosition } from './reducers/position';
 import { addImport, editCode, enableFeatureGate } from './reducers/code';
 import { browserWidthChanged } from './reducers/browser';
 import { selectText } from './reducers/selection';
+import { useAppSelector } from './hooks';
+import { themeSelector } from './selectors';
+import { Theme } from './types';
 
 const store = configureStore(window);
 
@@ -82,13 +85,28 @@ window.rustPlayground = {
   },
 };
 
+const ThemeProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const theme = useAppSelector(themeSelector);
+  React.useEffect(() => {
+    if (theme === Theme.System) {
+      delete document.documentElement.dataset['theme'];
+    } else {
+      document.documentElement.dataset['theme'] = theme;
+    }
+  }, [theme]);
+
+  return <>{children}</>;
+};
+
 const container = document.getElementById('playground');
 if (container) {
   const root = createRoot(container);
   root.render(
     <Provider store={store}>
       <Router store={store} reducer={playgroundApp}>
-        <PageSwitcher />
+        <ThemeProvider>
+          <PageSwitcher />
+        </ThemeProvider>
       </Router>
     </Provider>,
   );

--- a/ui/frontend/local_storage.ts
+++ b/ui/frontend/local_storage.ts
@@ -4,7 +4,7 @@
 
 import { State } from './reducers';
 import {removeVersion, initializeStorage, PartialState} from './storage';
-import { AssemblyFlavor, DemangleAssembly, Editor, Orientation, PairCharacters, ProcessAssembly } from './types';
+import { AssemblyFlavor, DemangleAssembly, Editor, Orientation, PairCharacters, ProcessAssembly, Theme } from './types';
 import { codeSelector } from './selectors';
 
 const CURRENT_VERSION = 2;
@@ -25,6 +25,7 @@ interface V2Configuration {
     monaco: {
       theme: string;
     };
+    theme: Theme;
     orientation: Orientation;
     assemblyFlavor: AssemblyFlavor;
     demangleAssembly: DemangleAssembly;
@@ -70,6 +71,7 @@ export function serialize(state: State): string {
       monaco: {
         theme: state.configuration.monaco.theme,
       },
+      theme: state.configuration.theme,
       orientation: state.configuration.orientation,
       assemblyFlavor: state.configuration.assemblyFlavor,
       demangleAssembly: state.configuration.demangleAssembly,
@@ -93,6 +95,7 @@ function migrateV1(state: V1Configuration): CurrentConfiguration {
       ...configuration,
       ace: { theme, keybinding, pairCharacters },
       monaco: { theme: 'vscode-dark-plus' },
+      theme: Theme.System,
       editor: editor === 'advanced' ? Editor.Ace : Editor.Simple,
     },
     version: 2,

--- a/ui/frontend/package.json
+++ b/ui/frontend/package.json
@@ -13,6 +13,7 @@
     "immer": "^10.0.3",
     "lodash-es": "^4.17.21",
     "monaco-editor": "^0.50.0",
+    "postcss-mixins": "^11.0.1",
     "prismjs": "^1.6.0",
     "qs": "^6.4.0",
     "react": "^18.2.0",

--- a/ui/frontend/pnpm-lock.yaml
+++ b/ui/frontend/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       monaco-editor:
         specifier: ^0.50.0
         version: 0.50.0
+      postcss-mixins:
+        specifier: ^11.0.1
+        version: 11.0.1(postcss@8.4.41)
       prismjs:
         specifier: ^1.6.0
         version: 1.29.0
@@ -1601,6 +1604,10 @@ packages:
   camel-case@4.1.2:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
 
+  camelcase-css@2.0.1:
+    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
+    engines: {node: '>= 6'}
+
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
@@ -2074,6 +2081,14 @@ packages:
 
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
+
+  fdir@6.3.0:
+    resolution: {integrity: sha512-QOnuT+BOtivR77wYvCWHfGt9s4Pz1VIMbD463vegT5MLqNXy8rYFT/lPVEqf/bhYeT6qmqrNHhsX+rWwe3rOCQ==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
@@ -3074,6 +3089,10 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
@@ -3093,6 +3112,12 @@ packages:
   possible-typed-array-names@1.0.0:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
     engines: {node: '>= 0.4'}
+
+  postcss-js@4.0.1:
+    resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: ^8.4.21
 
   postcss-less@6.0.0:
     resolution: {integrity: sha512-FPX16mQLyEjLzEuuJtxA8X3ejDLNGGEG503d2YGZR5Ask1SpDN8KmZUMpzCvyalWRywAn1n1VOA5dcqfCLo5rg==}
@@ -3127,6 +3152,12 @@ packages:
 
   postcss-media-query-parser@0.2.3:
     resolution: {integrity: sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==}
+
+  postcss-mixins@11.0.1:
+    resolution: {integrity: sha512-jM9F8bdfP6v/2kCV6Z1PbRribZqB7gh+grtgLnWayQLDo/nLLyEZtmMZ/od6n2YNkyWJo/CAKLHqWNmef0SMVA==}
+    engines: {node: ^18.0 || ^ 20.0 || >= 22.0}
+    peerDependencies:
+      postcss: ^8.2.14
 
   postcss-modules-extract-imports@3.1.0:
     resolution: {integrity: sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==}
@@ -3617,6 +3648,12 @@ packages:
     resolution: {integrity: sha512-v3YCf31atbwJQIMtPNX8hcQ+okD4NQaTuKGUWfII8eaqn+3otrbttGL1zSMZAAtiPsBztQnujVBugg/cXFUpyg==}
     hasBin: true
 
+  sugarss@4.0.1:
+    resolution: {integrity: sha512-WCjS5NfuVJjkQzK10s8WOBY+hhDxxNt/N6ZaGwxFZ+wN3/lKKFSaaKUNecULcTTvE4urLcKaZFQD8vO0mOZujw==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.3.3
+
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -3683,6 +3720,10 @@ packages:
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
+  tinyglobby@0.2.6:
+    resolution: {integrity: sha512-NbBoFBpqfcgd1tCiO8Lkfdk+xrA7mlLR9zgvZcZWQQwU63XAfUePyd6wZBaU93Hqw347lHnwFzttAkemHzzz4g==}
+    engines: {node: '>=12.0.0'}
 
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
@@ -5755,6 +5796,8 @@ snapshots:
       pascal-case: 3.1.2
       tslib: 2.6.3
 
+  camelcase-css@2.0.1: {}
+
   camelcase@5.3.1: {}
 
   camelcase@6.3.0: {}
@@ -6319,6 +6362,10 @@ snapshots:
   fb-watchman@2.0.2:
     dependencies:
       bser: 2.1.1
+
+  fdir@6.3.0(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
 
   file-entry-cache@6.0.1:
     dependencies:
@@ -7460,6 +7507,8 @@ snapshots:
 
   picomatch@2.3.1: {}
 
+  picomatch@4.0.2: {}
+
   pify@4.0.1:
     optional: true
 
@@ -7474,6 +7523,11 @@ snapshots:
       find-up: 6.3.0
 
   possible-typed-array-names@1.0.0: {}
+
+  postcss-js@4.0.1(postcss@8.4.41):
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.4.41
 
   postcss-less@6.0.0(postcss@8.4.41):
     dependencies:
@@ -7499,6 +7553,14 @@ snapshots:
 
   postcss-media-query-parser@0.2.3:
     optional: true
+
+  postcss-mixins@11.0.1(postcss@8.4.41):
+    dependencies:
+      postcss: 8.4.41
+      postcss-js: 4.0.1(postcss@8.4.41)
+      postcss-simple-vars: 7.0.1(postcss@8.4.41)
+      sugarss: 4.0.1(postcss@8.4.41)
+      tinyglobby: 0.2.6
 
   postcss-modules-extract-imports@3.1.0(postcss@8.4.41):
     dependencies:
@@ -8052,6 +8114,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  sugarss@4.0.1(postcss@8.4.41):
+    dependencies:
+      postcss: 8.4.41
+
   supports-color@5.5.0:
     dependencies:
       has-flag: 3.0.0
@@ -8112,6 +8178,11 @@ snapshots:
       minimatch: 3.1.2
 
   text-table@0.2.0: {}
+
+  tinyglobby@0.2.6:
+    dependencies:
+      fdir: 6.3.0(picomatch@4.0.2)
+      picomatch: 4.0.2
 
   tmpl@1.0.5: {}
 

--- a/ui/frontend/postcss.config.js
+++ b/ui/frontend/postcss.config.js
@@ -2,6 +2,7 @@ module.exports = {
   plugins: [
     require('postcss-simple-vars'),
     require('postcss-nesting'),
+    require('postcss-mixins'),
     require('autoprefixer')(),
-  ]
+  ],
 };

--- a/ui/frontend/reducers/configuration.ts
+++ b/ui/frontend/reducers/configuration.ts
@@ -45,7 +45,7 @@ const initialState: State = {
     pairCharacters: PairCharacters.Enabled,
   },
   monaco: {
-    theme: 'vscode-dark-plus',
+    theme: 'vs',
   },
   orientation: Orientation.Automatic,
   assemblyFlavor: AssemblyFlavor.Att,

--- a/ui/frontend/reducers/configuration.ts
+++ b/ui/frontend/reducers/configuration.ts
@@ -14,6 +14,7 @@ import {
   PrimaryAction,
   PrimaryActionAuto,
   ProcessAssembly,
+  Theme,
 } from '../types';
 
 interface State {
@@ -26,6 +27,7 @@ interface State {
   monaco: {
     theme: string;
   };
+  theme: Theme;
   orientation: Orientation;
   assemblyFlavor: AssemblyFlavor;
   demangleAssembly: DemangleAssembly;
@@ -47,6 +49,7 @@ const initialState: State = {
   monaco: {
     theme: 'vs',
   },
+  theme: Theme.System,
   orientation: Orientation.Automatic,
   assemblyFlavor: AssemblyFlavor.Att,
   demangleAssembly: DemangleAssembly.Demangle,
@@ -102,6 +105,10 @@ const slice = createSlice({
       state.monaco.theme = action.payload;
     },
 
+    changeTheme: (state, action: PayloadAction<Theme>) => {
+      state.theme = action.payload;
+    },
+
     changeOrientation: (state, action: PayloadAction<Orientation>) => {
       state.orientation = action.payload;
     },
@@ -131,6 +138,7 @@ export const {
   changeKeybinding,
   changeMode,
   changeMonacoTheme,
+  changeTheme,
   changeOrientation,
   changePairCharacters,
   changePrimaryAction,

--- a/ui/frontend/reducers/featureFlags.ts
+++ b/ui/frontend/reducers/featureFlags.ts
@@ -6,6 +6,7 @@ import { createWebsocketResponse } from '../websocketActions';
 interface State {
   forced: boolean;
   showGemThreshold: number;
+  showThemeThreshold: number;
 }
 
 const ENABLED = 1.0;
@@ -14,12 +15,14 @@ const DISABLED = -1.0;
 const initialState: State = {
   forced: false,
   showGemThreshold: DISABLED,
+  showThemeThreshold: DISABLED,
 };
 
 const { action: wsFeatureFlags, schema: wsFeatureFlagsSchema } = createWebsocketResponse(
   'featureFlags',
   z.object({
     showGemThreshold: z.number().nullish(),
+    showThemeThreshold: z.number().nullish(),
   }),
 );
 
@@ -30,10 +33,12 @@ const slice = createSlice({
     forceEnableAll: (state) => {
       state.forced = true;
       state.showGemThreshold = ENABLED;
+      state.showThemeThreshold = ENABLED;
     },
     forceDisableAll: (state) => {
       state.forced = true;
       state.showGemThreshold = DISABLED;
+      state.showThemeThreshold = DISABLED;
     },
   },
   extraReducers: (builder) => {
@@ -42,10 +47,14 @@ const slice = createSlice({
         return;
       }
 
-      const { showGemThreshold } = action.payload;
+      const { showGemThreshold, showThemeThreshold } = action.payload;
 
       if (showGemThreshold) {
         state.showGemThreshold = showGemThreshold;
+      }
+
+      if (showThemeThreshold) {
+        state.showThemeThreshold = showThemeThreshold;
       }
     });
   },

--- a/ui/frontend/selectors/index.ts
+++ b/ui/frontend/selectors/index.ts
@@ -10,6 +10,7 @@ import {
   Orientation,
   PrimaryActionAuto,
   PrimaryActionCore,
+  Theme,
   Version,
 } from '../types';
 
@@ -504,4 +505,9 @@ export const compileRequestPayloadSelector = createSelector(
     processAssembly: configuration.processAssembly,
     backtrace,
   }),
+);
+
+export const themeSelector = createSelector(
+  (state: State) => state,
+  (state) => state.configuration.theme,
 );

--- a/ui/frontend/selectors/index.ts
+++ b/ui/frontend/selectors/index.ts
@@ -10,7 +10,6 @@ import {
   Orientation,
   PrimaryActionAuto,
   PrimaryActionCore,
-  Theme,
   Version,
 } from '../types';
 
@@ -445,11 +444,13 @@ const websocket = (state: State) => state.websocket;
 const clientFeatureFlagThreshold = createSelector(client, (c) => c.featureFlagThreshold);
 
 const showGemThreshold = createSelector(featureFlags, ff => ff.showGemThreshold);
+const showThemeThreshold = createSelector(featureFlags, ff => ff.showThemeThreshold);
 
 const createFeatureFlagSelector = (ff: (state: State) => number) =>
   createSelector(clientFeatureFlagThreshold, ff, (c, ff) => c <= ff);
 
 export const showGemSelector = createFeatureFlagSelector(showGemThreshold);
+export const showThemeSelector = createFeatureFlagSelector(showThemeThreshold);
 
 export const executeViaWebsocketSelector = createSelector(websocket, (ws) => ws.connected);
 

--- a/ui/frontend/shared.module.css
+++ b/ui/frontend/shared.module.css
@@ -15,6 +15,7 @@
 }
 
 .-buttonReset {
+  color: var(--font-color);
   border: none;
   background: inherit;
   background-color: transparent; /* IE 11 */
@@ -27,7 +28,7 @@
 .-buttonAsLink {
   composes: -buttonReset;
   cursor: pointer;
-  color: #00e;
+  color: var(--link-color);
   user-select: text;
   text-decoration: underline;
 }

--- a/ui/frontend/types.ts
+++ b/ui/frontend/types.ts
@@ -68,6 +68,12 @@ export enum Orientation {
   Vertical = 'vertical',
 }
 
+export enum Theme {
+  Light = 'light',
+  Dark = 'dark',
+  System = 'system',
+}
+
 export enum AssemblyFlavor {
   Att = 'att',
   Intel = 'intel',


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-playground/issues/544

This uses the media query approach described in the issue. The dark theme I came up with here was created using the [dark reader](https://darkreader.org/) extension and some manual tweaking. I'm not a designer, so happy to change the colors further until it looks acceptable.

# `prefers-color-scheme: dark`
![image](https://github.com/rust-lang/rust-playground/assets/1665677/ed9bc87c-86cd-4425-8755-00582f1bfb15)

# `prefers-color-scheme: light` (unchanged)
![image](https://github.com/rust-lang/rust-playground/assets/1665677/dc6cdba8-757d-40ba-b0e2-66a79f12c241)