### PR TITLE
Limit concurrency of active backends, not Coordinators

### DIFF
--- a/compiler/base/orchestrator/Cargo.toml
+++ b/compiler/base/orchestrator/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 
 [workspace]
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(force_docker)'] }
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 asm-cleanup = { path = "../asm-cleanup" }

--- a/ui/src/server_axum/websocket.rs
+++ b/ui/src/server_axum/websocket.rs
@@ -9,7 +9,7 @@ use crate::{
 use axum::extract::ws::{Message, WebSocket};
 use futures::{future::Fuse, Future, FutureExt, StreamExt, TryFutureExt};
 use orchestrator::{
-    coordinator::{self, CoordinatorFactory, DockerBackend, LimitedCoordinator},
+    coordinator::{self, Coordinator, CoordinatorFactory, DockerBackend},
     DropErrorDetailsExt,
 };
 use snafu::prelude::*;
@@ -222,7 +222,7 @@ pub(crate) async fn handle(
 
 type TaggedError = (Error, Option<Meta>);
 type ResponseTx = mpsc::Sender<Result<MessageResponse, TaggedError>>;
-type SharedCoordinator = Arc<LimitedCoordinator<DockerBackend>>;
+type SharedCoordinator = Arc<Coordinator<DockerBackend>>;
 
 /// Manages a limited amount of access to the `Coordinator`.
 ///


### PR DESCRIPTION
Each `Coordinator` can have 0-3 backends running as it abstracts over {stable,beta,nightly} and each backend is lazily created and idled.

The "good" failure case was that we could be off by a factor of 3 in the upper bound. The catastrophic failure case was for the WebSocket connections where there are thousands of `Coordinator`s idling with very few of them actively compiling at a time. Setting a low limit would prevent connections, setting a high limit was basically pointless.