### PR TITLE
Creating the Coordinator is no longer async

### DIFF
--- a/compiler/base/orchestrator/src/coordinator.rs
+++ b/compiler/base/orchestrator/src/coordinator.rs
@@ -861,7 +861,7 @@ impl CoordinatorFactory {
         CoordinatorId { start, id }
     }
 
-    pub async fn build<B>(&self) -> Coordinator<B>
+    pub fn build<B>(&self) -> Coordinator<B>
     where
         B: Backend + From<CoordinatorId>,
     {
@@ -2849,30 +2849,30 @@ mod tests {
     static TEST_COORDINATOR_FACTORY: Lazy<CoordinatorFactory> =
         Lazy::new(|| CoordinatorFactory::new(*MAX_CONCURRENT_TESTS));
 
-    async fn new_coordinator_test() -> Coordinator<TestBackend> {
-        TEST_COORDINATOR_FACTORY.build().await
+    fn new_coordinator_test() -> Coordinator<TestBackend> {
+        TEST_COORDINATOR_FACTORY.build()
     }
 
-    async fn new_coordinator_docker() -> Coordinator<DockerBackend> {
-        TEST_COORDINATOR_FACTORY.build().await
+    fn new_coordinator_docker() -> Coordinator<DockerBackend> {
+        TEST_COORDINATOR_FACTORY.build()
     }
 
-    async fn new_coordinator() -> Coordinator<impl Backend> {
+    fn new_coordinator() -> Coordinator<impl Backend> {
         #[cfg(not(force_docker))]
         {
-            new_coordinator_test().await
+            new_coordinator_test()
         }
 
         #[cfg(force_docker)]
         {
-            new_coordinator_docker().await
+            new_coordinator_docker()
         }
     }
 
     #[tokio::test]
     #[snafu::report]
     async fn versions() -> Result<()> {
-        let coordinator = new_coordinator().await;
+        let coordinator = new_coordinator();
 
         let versions = coordinator.versions().with_timeout().await.unwrap();
 
@@ -2903,7 +2903,7 @@ mod tests {
     #[tokio::test]
     #[snafu::report]
     async fn execute_response() -> Result<()> {
-        let coordinator = new_coordinator().await;
+        let coordinator = new_coordinator();
 
         let response = coordinator
             .execute(new_execute_request())
@@ -2931,7 +2931,7 @@ mod tests {
         ];
 
         let tests = params.into_iter().map(|(mode, expected)| async move {
-            let coordinator = new_coordinator().await;
+            let coordinator = new_coordinator();
 
             let request = ExecuteRequest {
                 mode,
@@ -2971,7 +2971,7 @@ mod tests {
         let tests = params.into_iter().flat_map(|(code, works_in)| {
             Edition::ALL.into_iter().zip(works_in).map(
                 move |(edition, expected_to_work)| async move {
-                    let coordinator = new_coordinator().await;
+                    let coordinator = new_coordinator();
 
                     let request = ExecuteRequest {
                         code: code.into(),
@@ -3012,7 +3012,7 @@ mod tests {
         ];
 
         let tests = params.into_iter().map(|(crate_type, expected)| async move {
-            let coordinator = new_coordinator().await;
+            let coordinator = new_coordinator();
 
             let request = ExecuteRequest {
                 crate_type,
@@ -3045,7 +3045,7 @@ mod tests {
         let params = [(false, "Running `"), (true, "Running unittests")];
 
         let tests = params.into_iter().map(|(tests, expected)| async move {
-            let coordinator = new_coordinator().await;
+            let coordinator = new_coordinator();
 
             let request = ExecuteRequest {
                 code: code.into(),
@@ -3078,7 +3078,7 @@ mod tests {
         ];
 
         let tests = params.into_iter().map(|(backtrace, expected)| async move {
-            let coordinator = new_coordinator().await;
+            let coordinator = new_coordinator();
 
             let request = ExecuteRequest {
                 code: code.into(),
@@ -3107,7 +3107,7 @@ mod tests {
     #[tokio::test]
     #[snafu::report]
     async fn execute_stdin() -> Result<()> {
-        let coordinator = new_coordinator().await;
+        let coordinator = new_coordinator();
 
         let request = ExecuteRequest {
             code: r#"
@@ -3155,7 +3155,7 @@ mod tests {
     #[tokio::test]
     #[snafu::report]
     async fn execute_stdin_close() -> Result<()> {
-        let coordinator = new_coordinator().await;
+        let coordinator = new_coordinator();
 
         let request = ExecuteRequest {
             code: r#"
@@ -3213,7 +3213,7 @@ mod tests {
     #[tokio::test]
     #[snafu::report]
     async fn execute_kill() -> Result<()> {
-        let coordinator = new_coordinator().await;
+        let coordinator = new_coordinator();
 
         let request = ExecuteRequest {
             code: r#"
@@ -3272,7 +3272,7 @@ mod tests {
     #[tokio::test]
     #[snafu::report]
     async fn execute_status() -> Result<()> {
-        let coordinator = new_coordinator().await;
+        let coordinator = new_coordinator();
 
         let request = ExecuteRequest {
             code: r#"
@@ -3345,7 +3345,7 @@ mod tests {
     #[tokio::test]
     #[snafu::report]
     async fn compile_response() -> Result<()> {
-        let coordinator = new_coordinator().await;
+        let coordinator = new_coordinator();
 
         let req = CompileRequest {
             code: HELLO_WORLD_CODE.into(),
@@ -3366,7 +3366,7 @@ mod tests {
     #[tokio::test]
     #[snafu::report]
     async fn compile_streaming() -> Result<()> {
-        let coordinator = new_coordinator().await;
+        let coordinator = new_coordinator();
 
         let req = CompileRequest {
             code: HELLO_WORLD_CODE.into(),
@@ -3401,7 +3401,7 @@ mod tests {
     #[snafu::report]
     async fn compile_edition() -> Result<()> {
         for edition in Edition::ALL {
-            let coordinator = new_coordinator().await;
+            let coordinator = new_coordinator();
 
             let req = CompileRequest {
                 edition,
@@ -3447,7 +3447,7 @@ mod tests {
     #[tokio::test]
     #[snafu::report]
     async fn compile_assembly() -> Result<()> {
-        let coordinator = new_coordinator().await;
+        let coordinator = new_coordinator();
 
         let req = CompileRequest {
             code: ADD_CODE.into(),
@@ -3480,7 +3480,7 @@ mod tests {
         ];
 
         for (flavor, expected) in cases {
-            let coordinator = new_coordinator().await;
+            let coordinator = new_coordinator();
 
             let req = CompileRequest {
                 target: CompileTarget::Assembly(
@@ -3514,7 +3514,7 @@ mod tests {
         ];
 
         for (mangle, expected) in cases {
-            let coordinator = new_coordinator().await;
+            let coordinator = new_coordinator();
 
             let req = CompileRequest {
                 target: CompileTarget::Assembly(
@@ -3546,7 +3546,7 @@ mod tests {
         ];
 
         for (process, expected) in cases {
-            let coordinator = new_coordinator().await;
+            let coordinator = new_coordinator();
 
             let req = CompileRequest {
                 target: CompileTarget::Assembly(
@@ -3589,7 +3589,7 @@ mod tests {
     #[tokio::test]
     #[snafu::report]
     async fn compile_hir() -> Result<()> {
-        let coordinator = new_coordinator().await;
+        let coordinator = new_coordinator();
 
         let req = CompileRequest {
             code: SUBTRACT_CODE.into(),
@@ -3609,7 +3609,7 @@ mod tests {
     #[tokio::test]
     #[snafu::report]
     async fn compile_llvm_ir() -> Result<()> {
-        let coordinator = new_coordinator().await;
+        let coordinator = new_coordinator();
 
         let req = CompileRequest {
             target: CompileTarget::LlvmIr,
@@ -3636,7 +3636,7 @@ mod tests {
     #[snafu::report]
     async fn compile_wasm() -> Result<()> {
         // cargo-wasm only exists inside the container
-        let coordinator = new_coordinator_docker().await;
+        let coordinator = new_coordinator_docker();
 
         let req = CompileRequest {
             target: CompileTarget::Wasm,
@@ -3680,7 +3680,7 @@ mod tests {
     #[tokio::test]
     #[snafu::report]
     async fn format() -> Result<()> {
-        let coordinator = new_coordinator().await;
+        let coordinator = new_coordinator();
 
         let req = FormatRequest {
             code: ARBITRARY_FORMAT_INPUT.into(),
@@ -3702,7 +3702,7 @@ mod tests {
     #[snafu::report]
     async fn format_channel() -> Result<()> {
         for channel in Channel::ALL {
-            let coordinator = new_coordinator().await;
+            let coordinator = new_coordinator();
 
             let req = FormatRequest {
                 channel,
@@ -3731,7 +3731,7 @@ mod tests {
         ];
 
         for (code, works_in) in cases {
-            let coordinator = new_coordinator().await;
+            let coordinator = new_coordinator();
 
             for (edition, works) in Edition::ALL.into_iter().zip(works_in) {
                 let req = FormatRequest {
@@ -3760,7 +3760,7 @@ mod tests {
     #[tokio::test]
     #[snafu::report]
     async fn clippy() -> Result<()> {
-        let coordinator = new_coordinator().await;
+        let coordinator = new_coordinator();
 
         let req = ClippyRequest {
             code: r#"
@@ -3796,7 +3796,7 @@ mod tests {
         let tests = cases.into_iter().flat_map(|(code, expected_to_be_clean)| {
             Edition::ALL.into_iter().zip(expected_to_be_clean).map(
                 move |(edition, expected_to_be_clean)| async move {
-                    let coordinator = new_coordinator().await;
+                    let coordinator = new_coordinator();
 
                     let req = ClippyRequest {
                         edition,
@@ -3835,7 +3835,7 @@ mod tests {
     #[snafu::report]
     async fn miri() -> Result<()> {
         // cargo-miri-playground only exists inside the container
-        let coordinator = new_coordinator_docker().await;
+        let coordinator = new_coordinator_docker();
 
         let req = MiriRequest {
             code: r#"
@@ -3870,7 +3870,7 @@ mod tests {
     #[tokio::test]
     #[snafu::report]
     async fn macro_expansion() -> Result<()> {
-        let coordinator = new_coordinator().await;
+        let coordinator = new_coordinator();
 
         let req = MacroExpansionRequest {
             code: r#"
@@ -3904,7 +3904,7 @@ mod tests {
     #[tokio::test]
     #[snafu::report]
     async fn compile_clears_old_main_rs() -> Result<()> {
-        let coordinator = new_coordinator().await;
+        let coordinator = new_coordinator();
 
         // Create a main.rs file
         let req = ExecuteRequest {
@@ -3955,7 +3955,7 @@ mod tests {
     #[tokio::test]
     #[snafu::report]
     async fn still_usable_after_idle() -> Result<()> {
-        let mut coordinator = new_coordinator().await;
+        let mut coordinator = new_coordinator();
 
         let req = ExecuteRequest {
             channel: Channel::Stable,
@@ -3983,7 +3983,7 @@ mod tests {
     #[tokio::test]
     #[snafu::report]
     async fn exit_due_to_signal_is_reported() -> Result<()> {
-        let coordinator = new_coordinator().await;
+        let coordinator = new_coordinator();
 
         let req = ExecuteRequest {
             channel: Channel::Stable,
@@ -4021,7 +4021,7 @@ mod tests {
     #[snafu::report]
     async fn network_connections_are_disabled() -> Result<()> {
         // The limits are only applied to the container
-        let coordinator = new_coordinator_docker().await;
+        let coordinator = new_coordinator_docker();
 
         let req = ExecuteRequest {
             code: r#"
@@ -4049,7 +4049,7 @@ mod tests {
     #[snafu::report]
     async fn memory_usage_is_limited() -> Result<()> {
         // The limits are only applied to the container
-        let coordinator = new_coordinator_docker().await;
+        let coordinator = new_coordinator_docker();
 
         let req = ExecuteRequest {
             code: r#"
@@ -4078,7 +4078,7 @@ mod tests {
     #[snafu::report]
     async fn number_of_pids_is_limited() -> Result<()> {
         // The limits are only applied to the container
-        let coordinator = new_coordinator_docker().await;
+        let coordinator = new_coordinator_docker();
 
         let req = ExecuteRequest {
             code: r##"
@@ -4109,7 +4109,7 @@ mod tests {
     #[snafu::report]
     async fn amount_of_output_is_limited() -> Result<()> {
         // The limits are only applied to the container
-        let coordinator = new_coordinator_docker().await;
+        let coordinator = new_coordinator_docker();
 
         let req = ExecuteRequest {
             code: r##"

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -21,7 +21,6 @@ mod env;
 mod gist;
 mod metrics;
 mod request_database;
-mod sandbox;
 mod server_axum;
 
 fn main() {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1,7 +1,6 @@
 #![deny(rust_2018_idioms)]
 
 use orchestrator::coordinator::CoordinatorFactory;
-use snafu::prelude::*;
 use std::{
     net::SocketAddr,
     path::{Path, PathBuf},
@@ -183,13 +182,6 @@ impl GhToken {
     fn new(token: &Option<String>) -> Self {
         GhToken(token.clone().map(Arc::new))
     }
-
-    fn must_get(&self) -> Result<String> {
-        self.0
-            .as_ref()
-            .map(|s| String::clone(s))
-            .context(NoGithubTokenSnafu)
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -200,131 +192,3 @@ impl MetricsToken {
         MetricsToken(Arc::new(token.into()))
     }
 }
-
-#[derive(Debug, Snafu)]
-enum Error {
-    #[snafu(display("Gist creation failed: {}", source))]
-    GistCreation { source: octocrab::Error },
-    #[snafu(display("Gist loading failed: {}", source))]
-    GistLoading { source: octocrab::Error },
-    #[snafu(display("{PLAYGROUND_GITHUB_TOKEN} not set up for reading/writing gists"))]
-    NoGithubToken,
-    #[snafu(display("Unable to deserialize request: {}", source))]
-    Deserialization { source: serde_json::Error },
-
-    #[snafu(transparent)]
-    EvaluateRequest {
-        source: server_axum::api_orchestrator_integration_impls::ParseEvaluateRequestError,
-    },
-
-    #[snafu(transparent)]
-    CompileRequest {
-        source: server_axum::api_orchestrator_integration_impls::ParseCompileRequestError,
-    },
-
-    #[snafu(transparent)]
-    ExecuteRequest {
-        source: server_axum::api_orchestrator_integration_impls::ParseExecuteRequestError,
-    },
-
-    #[snafu(transparent)]
-    FormatRequest {
-        source: server_axum::api_orchestrator_integration_impls::ParseFormatRequestError,
-    },
-
-    #[snafu(transparent)]
-    ClippyRequest {
-        source: server_axum::api_orchestrator_integration_impls::ParseClippyRequestError,
-    },
-
-    #[snafu(transparent)]
-    MiriRequest {
-        source: server_axum::api_orchestrator_integration_impls::ParseMiriRequestError,
-    },
-
-    #[snafu(transparent)]
-    MacroExpansionRequest {
-        source: server_axum::api_orchestrator_integration_impls::ParseMacroExpansionRequestError,
-    },
-
-    #[snafu(display("The WebSocket worker panicked: {}", text))]
-    WebSocketTaskPanic { text: String },
-
-    #[snafu(display("Unable to find the available crates"))]
-    Crates {
-        source: orchestrator::coordinator::CratesError,
-    },
-
-    #[snafu(display("Unable to find the available versions"))]
-    Versions {
-        source: orchestrator::coordinator::VersionsError,
-    },
-
-    #[snafu(display("The Miri version was missing"))]
-    MiriVersion,
-
-    #[snafu(display("Unable to shutdown the coordinator"))]
-    ShutdownCoordinator {
-        source: orchestrator::coordinator::Error,
-    },
-
-    #[snafu(display("Unable to process the evaluate request"))]
-    Evaluate {
-        source: orchestrator::coordinator::ExecuteError,
-    },
-
-    #[snafu(display("Unable to process the compile request"))]
-    Compile {
-        source: orchestrator::coordinator::CompileError,
-    },
-
-    #[snafu(display("Unable to process the execute request"))]
-    Execute {
-        source: orchestrator::coordinator::ExecuteError,
-    },
-
-    #[snafu(display("Unable to process the format request"))]
-    Format {
-        source: orchestrator::coordinator::FormatError,
-    },
-
-    #[snafu(display("Unable to process the Clippy request"))]
-    Clippy {
-        source: orchestrator::coordinator::ClippyError,
-    },
-
-    #[snafu(display("Unable to process the Miri request"))]
-    Miri {
-        source: orchestrator::coordinator::MiriError,
-    },
-
-    #[snafu(display("Unable to process the macro expansion request"))]
-    MacroExpansion {
-        source: orchestrator::coordinator::MacroExpansionError,
-    },
-
-    #[snafu(display("The operation timed out"))]
-    Timeout { source: tokio::time::error::Elapsed },
-
-    #[snafu(display("Unable to spawn a coordinator task"))]
-    StreamingCoordinatorSpawn {
-        source: server_axum::WebsocketCoordinatorManagerError,
-    },
-
-    #[snafu(display("Unable to idle the coordinator"))]
-    StreamingCoordinatorIdle {
-        source: server_axum::WebsocketCoordinatorManagerError,
-    },
-
-    #[snafu(display("Unable to perform a streaming execute"))]
-    StreamingExecute {
-        source: server_axum::WebsocketExecuteError,
-    },
-
-    #[snafu(display("Unable to pass stdin to the active execution"))]
-    StreamingCoordinatorExecuteStdin {
-        source: tokio::sync::mpsc::error::SendError<()>,
-    },
-}
-
-type Result<T, E = Error> = ::std::result::Result<T, E>;

--- a/ui/src/metrics.rs
+++ b/ui/src/metrics.rs
@@ -17,11 +17,6 @@ lazy_static! {
         vec![0.1, 1.0, 2.5, 5.0, 10.0, 15.0]
     )
     .unwrap();
-    pub(crate) static ref ONE_OFF_QUEUE_DEPTH: IntGauge = register_int_gauge!(
-        "playground_one_off_coordinator_queue_depth",
-        "Number of clients waiting for a one-off coordinator"
-    )
-    .unwrap();
     pub(crate) static ref LIVE_WS: IntGauge = register_int_gauge!(
         "playground_active_websocket_connections_count",
         "Number of active WebSocket connections"

--- a/ui/src/metrics.rs
+++ b/ui/src/metrics.rs
@@ -207,13 +207,13 @@ impl Labels {
     }
 }
 
-pub(crate) async fn track_metric_no_request_async<B, Fut, Resp>(
+pub(crate) async fn track_metric_no_request_async<B, Fut, Resp, E>(
     endpoint: Endpoint,
     body: B,
-) -> crate::Result<Resp>
+) -> Result<Resp, E>
 where
     B: FnOnce() -> Fut,
-    Fut: Future<Output = crate::Result<Resp>>,
+    Fut: Future<Output = Result<Resp, E>>,
 {
     let start = Instant::now();
     let response = body().await;

--- a/ui/src/public_http_api.rs
+++ b/ui/src/public_http_api.rs
@@ -1,0 +1,197 @@
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ErrorJson {
+    pub(crate) error: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct CompileRequest {
+    pub(crate) target: String,
+    #[serde(rename = "assemblyFlavor")]
+    pub(crate) assembly_flavor: Option<String>,
+    #[serde(rename = "demangleAssembly")]
+    pub(crate) demangle_assembly: Option<String>,
+    #[serde(rename = "processAssembly")]
+    pub(crate) process_assembly: Option<String>,
+    pub(crate) channel: String,
+    pub(crate) mode: String,
+    #[serde(default)]
+    pub(crate) edition: String,
+    #[serde(rename = "crateType")]
+    pub(crate) crate_type: String,
+    pub(crate) tests: bool,
+    #[serde(default)]
+    pub(crate) backtrace: bool,
+    pub(crate) code: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct CompileResponse {
+    pub(crate) success: bool,
+    #[serde(rename = "exitDetail")]
+    pub(crate) exit_detail: String,
+    pub(crate) code: String,
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ExecuteRequest {
+    pub(crate) channel: String,
+    pub(crate) mode: String,
+    #[serde(default)]
+    pub(crate) edition: String,
+    #[serde(rename = "crateType")]
+    pub(crate) crate_type: String,
+    pub(crate) tests: bool,
+    #[serde(default)]
+    pub(crate) backtrace: bool,
+    pub(crate) code: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ExecuteResponse {
+    pub(crate) success: bool,
+    #[serde(rename = "exitDetail")]
+    pub(crate) exit_detail: String,
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct FormatRequest {
+    #[serde(default)]
+    pub(crate) channel: Option<String>,
+    #[serde(default)]
+    pub(crate) edition: String,
+    pub(crate) code: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct FormatResponse {
+    pub(crate) success: bool,
+    #[serde(rename = "exitDetail")]
+    pub(crate) exit_detail: String,
+    pub(crate) code: String,
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ClippyRequest {
+    #[serde(default)]
+    pub(crate) channel: Option<String>,
+    #[serde(default = "default_crate_type", rename = "crateType")]
+    pub(crate) crate_type: String,
+    #[serde(default)]
+    pub(crate) edition: String,
+    pub(crate) code: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ClippyResponse {
+    pub(crate) success: bool,
+    pub(crate) exit_detail: String,
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct MiriRequest {
+    pub(crate) code: String,
+    #[serde(default)]
+    pub(crate) edition: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct MiriResponse {
+    pub(crate) success: bool,
+    pub(crate) exit_detail: String,
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct MacroExpansionRequest {
+    pub(crate) code: String,
+    #[serde(default)]
+    pub(crate) edition: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct MacroExpansionResponse {
+    pub(crate) success: bool,
+    pub(crate) exit_detail: String,
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct CrateInformation {
+    pub(crate) name: String,
+    pub(crate) version: String,
+    pub(crate) id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct MetaCratesResponse {
+    pub(crate) crates: Arc<[CrateInformation]>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct MetaVersionsResponse {
+    pub(crate) stable: MetaChannelVersionResponse,
+    pub(crate) beta: MetaChannelVersionResponse,
+    pub(crate) nightly: MetaChannelVersionResponse,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct MetaChannelVersionResponse {
+    pub(crate) rustc: MetaVersionResponse,
+    pub(crate) rustfmt: MetaVersionResponse,
+    pub(crate) clippy: MetaVersionResponse,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) miri: Option<MetaVersionResponse>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct MetaVersionResponse {
+    pub(crate) version: Arc<str>,
+    pub(crate) hash: Arc<str>,
+    pub(crate) date: Arc<str>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct MetaGistCreateRequest {
+    pub(crate) code: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct MetaGistResponse {
+    pub(crate) id: String,
+    pub(crate) url: String,
+    pub(crate) code: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct EvaluateRequest {
+    pub(crate) version: String,
+    pub(crate) optimize: String,
+    pub(crate) code: String,
+    #[serde(default)]
+    pub(crate) edition: String,
+    #[serde(default)]
+    pub(crate) tests: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct EvaluateResponse {
+    pub(crate) result: String,
+    pub(crate) error: Option<String>,
+}
+
+fn default_crate_type() -> String {
+    "bin".into()
+}

--- a/ui/src/sandbox.rs
+++ b/ui/src/sandbox.rs
@@ -1,3 +1,0 @@
-use std::time::Duration;
-
-pub(crate) const DOCKER_PROCESS_TIMEOUT_SOFT: Duration = Duration::from_secs(10);

--- a/ui/src/server_axum.rs
+++ b/ui/src/server_axum.rs
@@ -2,7 +2,7 @@ use crate::{
     gist,
     metrics::{
         record_metric, track_metric_no_request_async, Endpoint, HasLabelsCore, Outcome,
-        ONE_OFF_QUEUE_DEPTH, UNAVAILABLE_WS,
+        UNAVAILABLE_WS,
     },
     request_database::{Handle, How},
     Config, GhToken, MetricsToken,
@@ -437,9 +437,7 @@ where
     for<'f> F:
         FnOnce(&'f coordinator::Coordinator<DockerBackend>, Req) -> BoxFuture<'f, Result<Resp>>,
 {
-    ONE_OFF_QUEUE_DEPTH.inc();
-    let coordinator = factory.build().await;
-    ONE_OFF_QUEUE_DEPTH.dec();
+    let coordinator = factory.build();
 
     let job = async {
         let req = req.try_into()?;
@@ -736,7 +734,7 @@ impl SandboxCache {
         &self,
         factory: &CoordinatorFactory,
     ) -> Result<Stamped<api::MetaCratesResponse>> {
-        let coordinator = factory.build::<DockerBackend>().await;
+        let coordinator = factory.build::<DockerBackend>();
 
         let c = self
             .crates
@@ -755,7 +753,7 @@ impl SandboxCache {
         &self,
         factory: &CoordinatorFactory,
     ) -> Result<Stamped<api::MetaVersionsResponse>> {
-        let coordinator = factory.build::<DockerBackend>().await;
+        let coordinator = factory.build::<DockerBackend>();
 
         let v = self
             .versions
@@ -771,7 +769,7 @@ impl SandboxCache {
     }
 
     async fn raw_versions(&self, factory: &CoordinatorFactory) -> Result<Stamped<Arc<Versions>>> {
-        let coordinator = factory.build::<DockerBackend>().await;
+        let coordinator = factory.build::<DockerBackend>();
 
         let rv = self
             .raw_versions

--- a/ui/src/server_axum.rs
+++ b/ui/src/server_axum.rs
@@ -5,7 +5,6 @@ use crate::{
         ONE_OFF_QUEUE_DEPTH, UNAVAILABLE_WS,
     },
     request_database::{Handle, How},
-    sandbox::DOCKER_PROCESS_TIMEOUT_SOFT,
     ClippyRequest, ClippyResponse, ClippySnafu, CompileRequest, CompileResponse, CompileSnafu,
     Config, CratesSnafu, Error, ErrorJson, EvaluateRequest, EvaluateResponse, EvaluateSnafu,
     ExecuteRequest, ExecuteResponse, ExecuteSnafu, FormatRequest, FormatResponse, FormatSnafu,
@@ -61,6 +60,8 @@ const SANDBOX_CACHE_TIME_TO_LIVE: Duration = TEN_MINUTES;
 
 const MAX_AGE_ONE_DAY: HeaderValue = HeaderValue::from_static("public, max-age=86400");
 const MAX_AGE_ONE_YEAR: HeaderValue = HeaderValue::from_static("public, max-age=31536000");
+
+const DOCKER_PROCESS_TIMEOUT_SOFT: Duration = Duration::from_secs(10);
 
 mod websocket;
 pub use websocket::CoordinatorManagerError as WebsocketCoordinatorManagerError;

--- a/ui/src/server_axum.rs
+++ b/ui/src/server_axum.rs
@@ -60,8 +60,6 @@ const MAX_AGE_ONE_YEAR: HeaderValue = HeaderValue::from_static("public, max-age=
 const DOCKER_PROCESS_TIMEOUT_SOFT: Duration = Duration::from_secs(10);
 
 mod websocket;
-pub use websocket::CoordinatorManagerError as WebsocketCoordinatorManagerError;
-pub(crate) use websocket::ExecuteError as WebsocketExecuteError;
 
 #[derive(Debug, Clone)]
 struct CoordinatorOneOffFactory(Arc<CoordinatorFactory>);
@@ -997,9 +995,6 @@ enum Error {
     #[snafu(display("{PLAYGROUND_GITHUB_TOKEN} not set up for reading/writing gists"))]
     NoGithubToken,
 
-    #[snafu(display("Unable to deserialize request"))]
-    Deserialization { source: serde_json::Error },
-
     #[snafu(transparent)]
     EvaluateRequest {
         source: api_orchestrator_integration_impls::ParseEvaluateRequestError,
@@ -1034,9 +1029,6 @@ enum Error {
     MacroExpansionRequest {
         source: api_orchestrator_integration_impls::ParseMacroExpansionRequestError,
     },
-
-    #[snafu(display("The WebSocket worker panicked: {}", text))]
-    WebSocketTaskPanic { text: String },
 
     #[snafu(display("Unable to find the available crates"))]
     Crates {
@@ -1093,24 +1085,6 @@ enum Error {
 
     #[snafu(display("The operation timed out"))]
     Timeout { source: tokio::time::error::Elapsed },
-
-    #[snafu(display("Unable to spawn a coordinator task"))]
-    StreamingCoordinatorSpawn {
-        source: WebsocketCoordinatorManagerError,
-    },
-
-    #[snafu(display("Unable to idle the coordinator"))]
-    StreamingCoordinatorIdle {
-        source: WebsocketCoordinatorManagerError,
-    },
-
-    #[snafu(display("Unable to perform a streaming execute"))]
-    StreamingExecute { source: WebsocketExecuteError },
-
-    #[snafu(display("Unable to pass stdin to the active execution"))]
-    StreamingCoordinatorExecuteStdin {
-        source: tokio::sync::mpsc::error::SendError<()>,
-    },
 }
 
 type Result<T, E = Error> = ::std::result::Result<T, E>;

--- a/ui/src/server_axum/websocket.rs
+++ b/ui/src/server_axum/websocket.rs
@@ -2,8 +2,6 @@ use crate::{
     metrics::{self, record_metric, Endpoint, HasLabelsCore, Outcome},
     request_database::{Handle, How},
     server_axum::api_orchestrator_integration_impls::*,
-    Error, Result, StreamingCoordinatorExecuteStdinSnafu, StreamingCoordinatorIdleSnafu,
-    StreamingCoordinatorSpawnSnafu, StreamingExecuteSnafu, WebSocketTaskPanicSnafu,
 };
 
 use axum::extract::ws::{Message, WebSocket};
@@ -31,6 +29,12 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{error, instrument, warn, Instrument};
+
+use super::{
+    DeserializationSnafu, Error, Result, StreamingCoordinatorExecuteStdinSnafu,
+    StreamingCoordinatorIdleSnafu, StreamingCoordinatorSpawnSnafu, StreamingExecuteSnafu,
+    WebSocketTaskPanicSnafu,
+};
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -533,7 +537,7 @@ async fn handle_msg(
 ) {
     use WSMessageRequest::*;
 
-    let msg = serde_json::from_str(&txt).context(crate::DeserializationSnafu);
+    let msg = serde_json::from_str(&txt).context(DeserializationSnafu);
 
     match msg {
         Ok(ExecuteRequest { payload, meta }) => {

--- a/ui/src/server_axum/websocket.rs
+++ b/ui/src/server_axum/websocket.rs
@@ -248,9 +248,9 @@ impl CoordinatorManager {
     const N_KINDS: usize = 1;
     const KIND_EXECUTE: usize = 0;
 
-    async fn new(factory: &CoordinatorFactory) -> Self {
+    fn new(factory: &CoordinatorFactory) -> Self {
         Self {
-            coordinator: Arc::new(factory.build().await),
+            coordinator: Arc::new(factory.build()),
             tasks: Default::default(),
             semaphore: Arc::new(Semaphore::new(Self::N_PARALLEL)),
             abort_handles: Default::default(),
@@ -360,7 +360,7 @@ async fn handle_core(
         return;
     }
 
-    let mut manager = CoordinatorManager::new(&factory).await;
+    let mut manager = CoordinatorManager::new(&factory);
     let mut session_timeout = pin!(time::sleep(CoordinatorManager::SESSION_TIMEOUT));
     let mut idle_timeout = pin!(Fuse::terminated());
 


### PR DESCRIPTION
The queue depth is no longer represented by the time taken to create
the `Coordinator` — that depth is now buried inside implementation
details — so I'm removing the metric.