### PR TITLE
Allow user to specify aliasing model for Miri

### DIFF
--- a/compiler/base/cargo-miri-playground
+++ b/compiler/base/cargo-miri-playground
@@ -3,5 +3,5 @@
 set -eu
 
 export MIRI_SYSROOT=~/.cache/miri
-export MIRIFLAGS="-Zmiri-disable-isolation"
+export MIRIFLAGS="${MIRIFLAGS:-} -Zmiri-disable-isolation"
 exec cargo miri run

--- a/compiler/build.sh
+++ b/compiler/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euv -o pipefail
 

--- a/compiler/fetch.sh
+++ b/compiler/fetch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euv -o pipefail
 

--- a/tests/spec/features/backtrace_spec.rb
+++ b/tests/spec/features/backtrace_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "A backtrace is shown for certain errors", type: :feature, js: tru
 
   context "backtraces are enabled" do
     before do
-      in_advanced_options_menu { choose 'enabled' }
+      in_advanced_options_menu { within(:config_option, 'Backtrace') { choose 'On' } }
       within(:header) { click_on("Run") }
     end
 

--- a/tests/spec/features/tools_spec.rb
+++ b/tests/spec/features/tools_spec.rb
@@ -54,6 +54,30 @@ RSpec.feature "Using third-party Rust tools", type: :feature, js: true do
     EOF
   end
 
+  scenario "configure Miri for tree borrows" do
+    editor.set code_valid_under_tree_borrows_but_not_stacked_borrows
+    in_advanced_options_menu { choose("tree") }
+    in_tools_menu { click_on("Miri") }
+
+    within(:output, :stdout) do
+      expect(page).to have_content %r{[1, 2]}, wait: 10
+    end
+
+    within(:output, :stderr) do
+      expect(page).to_not have_content %r{Undefined Behavior}
+    end
+  end
+
+  def code_valid_under_tree_borrows_but_not_stacked_borrows
+    <<~EOF
+    fn main() {
+        let val = [1u8, 2];
+        let ptr = &val[0] as *const u8;
+        let _val = unsafe { *ptr.add(1) };
+    }
+    EOF
+  end
+
   scenario "expand macros with the nightly compiler" do
     editor.set code_that_uses_macros
     in_tools_menu { click_on("Expand macros") }

--- a/tests/spec/spec_helper.rb
+++ b/tests/spec/spec_helper.rb
@@ -88,6 +88,12 @@ Capybara.add_selector(:notification) do
   css { '[data-test-id = "notification"]' }
 end
 
+Capybara.add_selector(:config_option) do
+  xpath do |label|
+    ".//div[span[contains(., '#{label}')]]"
+  end
+end
+
 RSpec.configure do |config|
   config.after(:example, :js) do
     page.execute_script <<~JS

--- a/ui/frontend/.prettierignore
+++ b/ui/frontend/.prettierignore
@@ -12,8 +12,10 @@ node_modules
 *.scss
 
 # Slowly migrate files that we've touched
+!AdvancedOptionsMenu.tsx
 !BuildMenu.tsx
 !ButtonSet.tsx
+!ConfigElement.tsx
 !Header.tsx
 !HelpExample.tsx
 !Notifications.tsx

--- a/ui/frontend/AdvancedOptionsMenu.tsx
+++ b/ui/frontend/AdvancedOptionsMenu.tsx
@@ -26,7 +26,7 @@ const AdvancedOptionsMenu: React.FC = () => {
       <SelectConfig
         name="Edition"
         value={edition}
-        isNotDefault={!isEditionDefault}
+        isDefault={isEditionDefault}
         onChange={changeEdition}
       >
         <option value={Edition.Rust2015}>2015</option>
@@ -41,7 +41,7 @@ const AdvancedOptionsMenu: React.FC = () => {
         a={Backtrace.Disabled}
         b={Backtrace.Enabled}
         value={backtrace}
-        isNotDefault={!isBacktraceDefault}
+        isDefault={isBacktraceDefault}
         onChange={changeBacktrace}
       />
     </MenuGroup>

--- a/ui/frontend/AdvancedOptionsMenu.tsx
+++ b/ui/frontend/AdvancedOptionsMenu.tsx
@@ -1,17 +1,29 @@
 import React, { useCallback } from 'react';
 
 import { Either as EitherConfig, Select as SelectConfig } from './ConfigElement';
+import MenuAside from './MenuAside';
 import MenuGroup from './MenuGroup';
 import { useAppDispatch, useAppSelector } from './hooks';
 import * as config from './reducers/configuration';
 import * as selectors from './selectors';
-import { Backtrace, Edition } from './types';
+import { AliasingModel, Backtrace, Edition } from './types';
+
+const MIRI_TREE_BORROWS_URL = 'https://github.com/rust-lang/miri#user-content--zmiri-tree-borrows';
+
+const TreeBorrowAside: React.FC = () => (
+  <MenuAside>
+    Code that is accepted by <a href={MIRI_TREE_BORROWS_URL}>Tree Borrows</a> may be declared
+    undefined behavior in the future.
+  </MenuAside>
+);
 
 const AdvancedOptionsMenu: React.FC = () => {
   const isEditionDefault = useAppSelector(selectors.isEditionDefault);
   const edition = useAppSelector((state) => state.configuration.edition);
   const isBacktraceDefault = useAppSelector(selectors.isBacktraceDefault);
   const backtrace = useAppSelector((state) => state.configuration.backtrace);
+  const isAliasingModelDefault = useAppSelector(selectors.isAliasingModelDefault);
+  const aliasingModel = useAppSelector((state) => state.configuration.aliasingModel);
 
   const dispatch = useAppDispatch();
 
@@ -20,33 +32,52 @@ const AdvancedOptionsMenu: React.FC = () => {
     (b: Backtrace) => dispatch(config.changeBacktrace(b)),
     [dispatch],
   );
+  const changeAliasingModel = useCallback(
+    (b: AliasingModel) => dispatch(config.changeAliasingModel(b)),
+    [dispatch],
+  );
 
   return (
-    <MenuGroup title="Advanced options">
-      <SelectConfig
-        name="Edition"
-        value={edition}
-        isDefault={isEditionDefault}
-        onChange={changeEdition}
-      >
-        <option value={Edition.Rust2015}>2015</option>
-        <option value={Edition.Rust2018}>2018</option>
-        <option value={Edition.Rust2021}>2021</option>
-        <option value={Edition.Rust2024}>2024</option>
-      </SelectConfig>
+    <>
+      <MenuGroup title="Advanced options">
+        <SelectConfig
+          name="Edition"
+          value={edition}
+          isDefault={isEditionDefault}
+          onChange={changeEdition}
+        >
+          <option value={Edition.Rust2015}>2015</option>
+          <option value={Edition.Rust2018}>2018</option>
+          <option value={Edition.Rust2021}>2021</option>
+          <option value={Edition.Rust2024}>2024</option>
+        </SelectConfig>
 
-      <EitherConfig
-        id="backtrace"
-        name="Backtrace"
-        a={Backtrace.Enabled}
-        b={Backtrace.Disabled}
-        aLabel="On"
-        bLabel="Off"
-        value={backtrace}
-        isDefault={isBacktraceDefault}
-        onChange={changeBacktrace}
-      />
-    </MenuGroup>
+        <EitherConfig
+          id="backtrace"
+          name="Backtrace"
+          a={Backtrace.Enabled}
+          b={Backtrace.Disabled}
+          aLabel="On"
+          bLabel="Off"
+          value={backtrace}
+          isDefault={isBacktraceDefault}
+          onChange={changeBacktrace}
+        />
+      </MenuGroup>
+
+      <MenuGroup title="Miri">
+        <EitherConfig
+          id="aliasingModel"
+          name="Aliasing model"
+          a={AliasingModel.Stacked}
+          b={AliasingModel.Tree}
+          value={aliasingModel}
+          isDefault={isAliasingModelDefault}
+          onChange={changeAliasingModel}
+          aside={<TreeBorrowAside />}
+        />
+      </MenuGroup>
+    </>
   );
 };
 

--- a/ui/frontend/AdvancedOptionsMenu.tsx
+++ b/ui/frontend/AdvancedOptionsMenu.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback } from 'react';
 
-import * as config from './reducers/configuration';
 import { Either as EitherConfig, Select as SelectConfig } from './ConfigElement';
 import MenuGroup from './MenuGroup';
+import { useAppDispatch, useAppSelector } from './hooks';
+import * as config from './reducers/configuration';
 import * as selectors from './selectors';
 import { Backtrace, Edition } from './types';
-import { useAppDispatch, useAppSelector } from './hooks';
 
 const AdvancedOptionsMenu: React.FC = () => {
   const isEditionDefault = useAppSelector(selectors.isEditionDefault);
@@ -16,7 +16,10 @@ const AdvancedOptionsMenu: React.FC = () => {
   const dispatch = useAppDispatch();
 
   const changeEdition = useCallback((e: Edition) => dispatch(config.changeEdition(e)), [dispatch]);
-  const changeBacktrace = useCallback((b: Backtrace) => dispatch(config.changeBacktrace(b)), [dispatch]);
+  const changeBacktrace = useCallback(
+    (b: Backtrace) => dispatch(config.changeBacktrace(b)),
+    [dispatch],
+  );
 
   return (
     <MenuGroup title="Advanced options">
@@ -39,7 +42,8 @@ const AdvancedOptionsMenu: React.FC = () => {
         b={Backtrace.Enabled}
         value={backtrace}
         isNotDefault={isBacktraceSet}
-        onChange={changeBacktrace} />
+        onChange={changeBacktrace}
+      />
     </MenuGroup>
   );
 };

--- a/ui/frontend/AdvancedOptionsMenu.tsx
+++ b/ui/frontend/AdvancedOptionsMenu.tsx
@@ -10,7 +10,7 @@ import { Backtrace, Edition } from './types';
 const AdvancedOptionsMenu: React.FC = () => {
   const isEditionDefault = useAppSelector(selectors.isEditionDefault);
   const edition = useAppSelector((state) => state.configuration.edition);
-  const isBacktraceSet = useAppSelector(selectors.getBacktraceSet);
+  const isBacktraceDefault = useAppSelector(selectors.isBacktraceDefault);
   const backtrace = useAppSelector((state) => state.configuration.backtrace);
 
   const dispatch = useAppDispatch();
@@ -41,7 +41,7 @@ const AdvancedOptionsMenu: React.FC = () => {
         a={Backtrace.Disabled}
         b={Backtrace.Enabled}
         value={backtrace}
-        isNotDefault={isBacktraceSet}
+        isNotDefault={!isBacktraceDefault}
         onChange={changeBacktrace}
       />
     </MenuGroup>

--- a/ui/frontend/AdvancedOptionsMenu.tsx
+++ b/ui/frontend/AdvancedOptionsMenu.tsx
@@ -38,8 +38,10 @@ const AdvancedOptionsMenu: React.FC = () => {
       <EitherConfig
         id="backtrace"
         name="Backtrace"
-        a={Backtrace.Disabled}
-        b={Backtrace.Enabled}
+        a={Backtrace.Enabled}
+        b={Backtrace.Disabled}
+        aLabel="On"
+        bLabel="Off"
         value={backtrace}
         isDefault={isBacktraceDefault}
         onChange={changeBacktrace}

--- a/ui/frontend/ConfigElement.tsx
+++ b/ui/frontend/ConfigElement.tsx
@@ -70,16 +70,21 @@ export const Select = <T extends string>({
 interface ConfigElementProps {
   children?: React.ReactNode;
   name: string;
-  isNotDefault?: boolean;
+  isDefault?: boolean;
   aside?: JSX.Element;
 }
 
-const ConfigElement: React.FC<ConfigElementProps> = ({ name, isNotDefault, aside, children }) => (
-  <MenuItem>
-    <div className={styles.container}>
-      <span className={isNotDefault ? styles.notDefault : styles.name}>{name}</span>
-      <div className={styles.value}>{children}</div>
-    </div>
-    {aside}
-  </MenuItem>
-);
+const ConfigElement: React.FC<ConfigElementProps> = ({ name, isDefault, aside, children }) => {
+  const actuallyDefault = isDefault ?? true;
+  const defaultStyle = actuallyDefault ? styles.name : styles.notDefault;
+
+  return (
+    <MenuItem>
+      <div className={styles.container}>
+        <span className={defaultStyle}>{name}</span>
+        <div className={styles.value}>{children}</div>
+      </div>
+      {aside}
+    </MenuItem>
+  );
+};

--- a/ui/frontend/ConfigElement.tsx
+++ b/ui/frontend/ConfigElement.tsx
@@ -14,27 +14,39 @@ interface EitherProps<T extends string> extends ConfigElementProps {
   onChange: (_: T) => void;
 }
 
-export const Either =
-  <T extends string,>({ id, a, b, aLabel = a, bLabel = b, value, onChange, ...rest }: EitherProps<T>) => (
-    <ConfigElement {...rest}>
-      <div className={styles.toggle}>
-        <input id={`${id}-a`}
-          name={id}
-          value={a}
-          type="radio"
-          checked={value === a}
-          onChange={() => onChange(a as T)} />
-        <label htmlFor={`${id}-a`}>{aLabel}</label>
-        <input id={`${id}-b`}
-          name={id}
-          value={b}
-          type="radio"
-          checked={value === b}
-          onChange={() => onChange(b as T)} />
-        <label htmlFor={`${id}-b`}>{bLabel}</label>
-      </div>
-    </ConfigElement>
-  );
+export const Either = <T extends string>({
+  id,
+  a,
+  b,
+  aLabel = a,
+  bLabel = b,
+  value,
+  onChange,
+  ...rest
+}: EitherProps<T>) => (
+  <ConfigElement {...rest}>
+    <div className={styles.toggle}>
+      <input
+        id={`${id}-a`}
+        name={id}
+        value={a}
+        type="radio"
+        checked={value === a}
+        onChange={() => onChange(a as T)}
+      />
+      <label htmlFor={`${id}-a`}>{aLabel}</label>
+      <input
+        id={`${id}-b`}
+        name={id}
+        value={b}
+        type="radio"
+        checked={value === b}
+        onChange={() => onChange(b as T)}
+      />
+      <label htmlFor={`${id}-b`}>{bLabel}</label>
+    </div>
+  </ConfigElement>
+);
 
 interface SelectProps<T extends string> extends ConfigElementProps {
   children: React.ReactNode;
@@ -42,9 +54,14 @@ interface SelectProps<T extends string> extends ConfigElementProps {
   onChange: (_: T) => void;
 }
 
-export const Select = <T extends string,>({ value, onChange, children, ...rest }: SelectProps<T>) => (
+export const Select = <T extends string>({
+  value,
+  onChange,
+  children,
+  ...rest
+}: SelectProps<T>) => (
   <ConfigElement {...rest}>
-    <select className={styles.select} value={value} onChange={e => onChange(e.target.value as T)}>
+    <select className={styles.select} value={value} onChange={(e) => onChange(e.target.value as T)}>
       {children}
     </select>
   </ConfigElement>
@@ -54,16 +71,14 @@ interface ConfigElementProps {
   children?: React.ReactNode;
   name: string;
   isNotDefault?: boolean;
-  aside?: JSX.Element,
+  aside?: JSX.Element;
 }
 
 const ConfigElement: React.FC<ConfigElementProps> = ({ name, isNotDefault, aside, children }) => (
   <MenuItem>
     <div className={styles.container}>
       <span className={isNotDefault ? styles.notDefault : styles.name}>{name}</span>
-      <div className={styles.value}>
-        {children}
-      </div>
+      <div className={styles.value}>{children}</div>
     </div>
     {aside}
   </MenuItem>

--- a/ui/frontend/reducers/configuration.ts
+++ b/ui/frontend/reducers/configuration.ts
@@ -1,6 +1,7 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 import {
+  AliasingModel,
   AssemblyFlavor,
   Backtrace,
   Channel,
@@ -36,6 +37,7 @@ interface State {
   mode: Mode;
   edition: Edition;
   backtrace: Backtrace;
+  aliasingModel: AliasingModel;
 }
 
 const initialState: State = {
@@ -58,6 +60,7 @@ const initialState: State = {
   mode: Mode.Debug,
   edition: Edition.Rust2024,
   backtrace: Backtrace.Disabled,
+  aliasingModel: AliasingModel.Stacked,
 };
 
 const slice = createSlice({
@@ -74,6 +77,10 @@ const slice = createSlice({
 
     changeBacktrace: (state, action: PayloadAction<Backtrace>) => {
       state.backtrace = action.payload;
+    },
+
+    changeAliasingModel: (state, action: PayloadAction<AliasingModel>) => {
+      state.aliasingModel = action.payload;
     },
 
     changeChannel: (state, action: PayloadAction<Channel>) => {
@@ -146,6 +153,7 @@ export const {
   changeAceTheme,
   changeAssemblyFlavor,
   changeBacktrace,
+  changeAliasingModel,
   changeChannel,
   changeDemangleAssembly,
   changeEdition,

--- a/ui/frontend/reducers/output/miri.ts
+++ b/ui/frontend/reducers/output/miri.ts
@@ -4,6 +4,7 @@ import * as z from 'zod';
 import { jsonPost, routes } from '../../api';
 import { State as RootState } from '../../reducers';
 import { miriRequestSelector } from '../../selectors';
+import { AliasingModel } from '../../types';
 
 const sliceName = 'output/miri';
 
@@ -21,6 +22,7 @@ interface State {
 interface MiriRequestBody {
   code: string;
   edition: string;
+  aliasingModel: AliasingModel;
 }
 
 const MiriResponseBody = z.object({

--- a/ui/frontend/selectors/index.ts
+++ b/ui/frontend/selectors/index.ts
@@ -172,18 +172,18 @@ export const getChannelLabel = createSelector(channelSelector, (channel) => `${c
 
 export const isEditionDefault = createSelector(
   editionSelector,
-  edition => edition == Edition.Rust2024,
+  edition => edition === Edition.Rust2024,
 );
 
-export const getBacktraceSet = (state: State) => (
-  state.configuration.backtrace !== Backtrace.Disabled
+export const isBacktraceDefault = (state: State) => (
+  state.configuration.backtrace === Backtrace.Disabled
 );
+
+export const getBacktraceSet = createSelector(isBacktraceDefault, (b) => !b);
 
 export const getAdvancedOptionsSet = createSelector(
-  isEditionDefault, getBacktraceSet,
-  (editionDefault, backtraceSet) => (
-    !editionDefault || backtraceSet
-  ),
+  isEditionDefault, isBacktraceDefault,
+  (...areDefault) => !areDefault.every(n => n),
 );
 
 export const hasProperties = (obj: object) => Object.values(obj).some(val => !!val);

--- a/ui/frontend/selectors/index.ts
+++ b/ui/frontend/selectors/index.ts
@@ -6,6 +6,7 @@ import {
   Backtrace,
   Channel,
   Edition,
+  AliasingModel,
   Focus,
   Orientation,
   PrimaryActionAuto,
@@ -147,6 +148,7 @@ export const rustfmtVersionDetailsText = createSelector(getRustfmt, versionDetai
 export const miriVersionDetailsText = createSelector(getMiri, versionDetails);
 
 const editionSelector = (state: State) => state.configuration.edition;
+export const aliasingModelSelector = (state: State) => state.configuration.aliasingModel;
 
 export const isNightlyChannel = createSelector(
   channelSelector,
@@ -181,8 +183,13 @@ export const isBacktraceDefault = (state: State) => (
 
 export const getBacktraceSet = createSelector(isBacktraceDefault, (b) => !b);
 
+export const isAliasingModelDefault = createSelector(
+  aliasingModelSelector,
+  aliasingModel => aliasingModel == AliasingModel.Stacked,
+);
+
 export const getAdvancedOptionsSet = createSelector(
-  isEditionDefault, isBacktraceDefault,
+  isEditionDefault, isBacktraceDefault, isAliasingModelDefault,
   (...areDefault) => !areDefault.every(n => n),
 );
 
@@ -391,7 +398,8 @@ export const formatRequestSelector = createSelector(
 export const miriRequestSelector = createSelector(
   editionSelector,
   codeSelector,
-  (edition, code) => ({ edition, code }),
+  aliasingModelSelector,
+  (edition, code, aliasingModel) => ({ edition, code, aliasingModel }),
 );
 
 export const macroExpansionRequestSelector = createSelector(

--- a/ui/frontend/types.ts
+++ b/ui/frontend/types.ts
@@ -150,6 +150,11 @@ export enum Backtrace {
   Enabled = 'enabled',
 }
 
+export enum AliasingModel {
+  Stacked = 'stacked',
+  Tree = 'tree',
+}
+
 export enum Focus {
   Clippy = 'clippy',
   Miri = 'miri',

--- a/ui/src/metrics.rs
+++ b/ui/src/metrics.rs
@@ -361,6 +361,7 @@ impl HasLabelsCore for coordinator::MiriRequest {
             channel,
             crate_type,
             edition,
+            aliasing_model: _,
             code: _,
         } = *self;
 

--- a/ui/src/public_http_api.rs
+++ b/ui/src/public_http_api.rs
@@ -103,6 +103,8 @@ pub(crate) struct MiriRequest {
     pub(crate) code: String,
     #[serde(default)]
     pub(crate) edition: String,
+    #[serde(default, rename = "aliasingModel")]
+    pub(crate) aliasing_model: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
Very useful for comparing stacked borrows and tree borrows.

An example for testing:
```rust
fn main() {
    let val = [1u8, 2];
    let ptr = &val[0] as *const u8;
    let _val = unsafe { *ptr.add(1) };
}
```
is valid under Tree Borrows, but not under Stacked Borrows.

UI looks like this:

![image](https://github.com/user-attachments/assets/e138da26-65fc-457d-a0b2-449c487cd056)