### PR TITLE
Add the trpl crate to support The Book exercises

### DIFF
--- a/top-crates/crate-modifications.toml
+++ b/top-crates/crate-modifications.toml
@@ -17,4 +17,6 @@ additions = [
     "async-trait",
     "once_cell",
     "sptr",
+    # Crate that The Rust Programming Language book uses
+    "trpl",
 ]


### PR DESCRIPTION
In the upcoming async chapter, because the standard library doesn't include an async runtime, we need to use crates.

To make it easier to manage versions and updates, we've created a shim crate named `trpl` that mostly re-exports relevant parts of other crates in a way that we can control, to ensure the best experience for book readers.

While this crate may organically end up in the most-used crates included in the playground *eventually*, we'd love for the `trpl` crate to be available in the playground for readers before the chapter is officially published.

Thank you! ❤️ 