### PR TITLE
Display Axum server IP and Port info with `RUST_LOG=info`

### DIFF
--- a/ui/src/server_axum.rs
+++ b/ui/src/server_axum.rs
@@ -156,7 +156,10 @@ pub(crate) async fn serve(config: Config) {
         MakeRequestUuid::default(),
     ));
 
-    let listener = tokio::net::TcpListener::bind(config.server_socket_addr())
+    let server_socket_addr = config.server_socket_addr();
+    tracing::info!("Serving playground backend at http://{server_socket_addr}");
+
+    let listener = tokio::net::TcpListener::bind(server_socket_addr)
         .await
         .unwrap();
 


### PR DESCRIPTION
When running the server, I noticed IP/port info of the Axum server were not shown.

Running `RUST_LOG=info` will show this now.