### PR TITLE
Show the WebSocket execution progress indicator earlier

### DIFF
--- a/ui/frontend/reducers/output/execute.ts
+++ b/ui/frontend/reducers/output/execute.ts
@@ -129,6 +129,8 @@ const slice = createSlice({
         if (sequenceNumber >= (state.sequenceNumber ?? 0)) {
           state.sequenceNumber = sequenceNumber;
         }
+
+        state.requestsInProgress = 1; // Only tracking one request
       },
 
       prepare: (payload: wsExecuteRequestPayload) => ({
@@ -179,7 +181,6 @@ const slice = createSlice({
       .addCase(
         wsExecuteBegin,
         sequenceNumberMatches((state) => {
-          state.requestsInProgress = 1; // Only tracking one request
           state.stdout = '';
           state.stderr = '';
           delete state.error;


### PR DESCRIPTION
Touches on #1093. We aren't actually timing out, we are just waiting
for a long time. This is a trivial fix, but the bigger fix would be to
indicate that there might be a long wait or offer a deliberate cancel.