### PR TITLE
Increasing zerocopy (and zerocopy-derive) version from 0.7.35 to 0.8.14

### DIFF
--- a/compiler/base/Cargo.toml
+++ b/compiler/base/Cargo.toml
@@ -1817,12 +1817,12 @@ version = "=0.7.5"
 
 [dependencies.zerocopy]
 package = "zerocopy"
-version = "=0.7.35"
+version = "=0.8.14"
 features = ["__internal_use_only_features_that_work_on_stable", "alloc", "byteorder", "derive", "simd", "zerocopy-derive"]
 
 [dependencies.zerocopy_derive]
 package = "zerocopy-derive"
-version = "=0.7.35"
+version = "=0.8.14"
 
 [dependencies.zerofrom]
 package = "zerofrom"


### PR DESCRIPTION
Existing import of https://docs.rs/zerocopy/0.7.35/zerocopy/ is superseded by https://docs.rs/zerocopy/0.8.14/zerocopy (the current). There are (probably/hopefully only) minor incompatibilities.

Current (0.8.14-based) defines new functionality (`KnownLayout`, `Immutable` traits and their derives). There is no value in importing the old version and keeping any old gists/examples working, since that will only confuse any newcomers. Actually, if people notice that their existing gists/examples fail, hopefully they will have more heads up time to migrate.

Feel free to ask Zerocopy maintainers @joshlf and @jswrenn.

Dear Zerocopy maintainers, if you have a "Release"/major API change checklist (even though anything before 1.0.0 is considered unstable, of course), suggest updating/notifying rust-playground, too.

Thank you in advance to all of you.