### PR TITLE
Update derive_more and include all features

### DIFF
--- a/compiler/base/Cargo.toml
+++ b/compiler/base/Cargo.toml
@@ -356,9 +356,8 @@ version = "=2.2.0"
 
 [dependencies.derive_more]
 package = "derive_more"
-version = "=0.99.18"
-features = ["add", "add_assign"]
-default-features = false
+version = "=2.0.0"
+features = ["full"]
 
 [dependencies.destructure_traitobject]
 package = "destructure_traitobject"

--- a/compiler/base/crate-information.json
+++ b/compiler/base/crate-information.json
@@ -356,7 +356,7 @@
   },
   {
     "name": "derive_more",
-    "version": "0.99.18",
+    "version": "2.0.0",
     "id": "derive_more"
   },
   {


### PR DESCRIPTION
The `derive_more` version in the playground was outdated and didn't include many of the features that the library provides. This fixes that. 

(I'm the original author of `derive_more` and I was very happy to find out it is available on the playground)
